### PR TITLE
Upgraded to the Firebase 3.x.x SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
     <!-- Vue -->
     <script src="https://cdn.jsdelivr.net/vue/latest/vue.js"></script>
     <!-- Firebase -->
-    <script src="https://cdn.firebase.com/js/client/2.4.2/firebase.js"></script>
+    <script src="https://gstatic.com/firebasejs/3.0.3/firebase.js"></script>
     <!-- VueFire -->
-    <script src="https://cdn.jsdelivr.net/vuefire/1.0.0/vuefire.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/vuefire/1.1.0/vuefire.min.js"></script>
   </head>
   ```
 
@@ -35,16 +35,19 @@
 ## Usage
 
 ``` js
+var firebaseApp = firebase.initializeApp({ ... })
+var db = firebaseApp.database()
+
 var vm = new Vue({
   el: '#demo',
   firebase: {
     // simple syntax, bind as an array by default
-    anArray: new Firebase('url/to/my/collection'),
+    anArray: db.ref('url/to/my/collection'),
     // can also bind to a query
-    // anArray: new Firebase('url/to/my/collection').limitToLast(25)
+    // anArray: db.ref('url/to/my/collection').limitToLast(25)
     // full syntax
     anObject: {
-      source: new Firebase('url/to/my/object'),
+      source: db.ref('url/to/my/object'),
       // optionally bind as an object
       asObject: true,
       // optionally provide the cancelCallback

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuefire",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Firebase bindings for Vue.js",
   "main": "dist/vuefire.js",
   "files": [
@@ -32,6 +32,9 @@
     "url": "https://github.com/vuejs/vuefire/issues"
   },
   "homepage": "https://github.com/vuejs/vuefire#readme",
+  "peerDependencies": {
+    "firebase": "^2.4.1 || 3.x.x"
+  },
   "devDependencies": {
     "chai": "^3.5.0",
     "codecov": "^1.0.1",
@@ -40,7 +43,6 @@
     "eslint-plugin-html": "^1.4.0",
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",
-    "firebase": "^2.4.1",
     "istanbul-instrumenter-loader": "^0.2.0",
     "karma": "^0.13.22",
     "karma-coverage": "^0.5.5",

--- a/tests/vuefire.spec.js
+++ b/tests/vuefire.spec.js
@@ -5,13 +5,16 @@ var helpers = require('./helpers')
 
 Vue.use(VueFire)
 
-var demoFirebaseUrl = 'https://' + helpers.generateRandomString() + '.firebaseio-demo.com'
+var firebaseApp = Firebase.initializeApp({
+  apiKey: helpers.generateRandomString(),
+  databaseURL: 'https://' + helpers.generateRandomString() + '.firebaseio-demo.com'
+})
 
 describe('VueFire', function () {
   var firebaseRef
 
   beforeEach(function (done) {
-    firebaseRef = new Firebase(demoFirebaseUrl)
+    firebaseRef = firebaseApp.database().ref()
     firebaseRef.remove(function (error) {
       if (error) {
         done(error)
@@ -595,7 +598,7 @@ describe('VueFire', function () {
     })
 
     it('sets the key as null when bound to the root of the database', function (done) {
-      var rootRef = firebaseRef.root()
+      var rootRef = firebaseRef.root
       var vm = new Vue({
         firebase: {
           items: {


### PR DESCRIPTION
I would like to refer to the change about .key/.value. I believe that the `item._key` it is more clean and readable than the `item['.key']`.
For details about the other changes, you could check the updated readme.

Let me know if you agree with that changes, to continue with tests.