### PR TITLE
Mentioned callback functions for manual binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,11 @@ Alternatively, you can also manually bind to a Firebase ref with the `$bindAsObj
 ``` js
 vm.$bindAsObject('user', myFirebaseRef.child('user'))
 vm.$bindAsArray('items', myFirebaseRef.child('items').limitToLast(25))
-//These instance methods can also take the optional cancelCallback and readyCallback callbacks functions as
-//a third and fourth arguments.
-//Example of using readyCallback:
-vm.$bindAsObject('user', myFirebaseRef.child('user'), null, function () {})
+// You can also pass cancelCallback and readyCallback callbacks functions as
+// a third and fourth arguments. Any of them can be omitted by passing null
+vm.$bindAsObject('user', myFirebaseRef.child('user'), null, () => console.log('Ready fired!'))
 
-// References are unbinded when the component is destroyed but you can manually unbind a reference
+// References are unbound when the component is destroyed but you can manually unbind a reference
 // if needed
 vm.$unbind('items')
 ```

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Alternatively, you can also manually bind to a Firebase ref with the `$bindAsObj
 ``` js
 vm.$bindAsObject('user', myFirebaseRef.child('user'))
 vm.$bindAsArray('items', myFirebaseRef.child('items').limitToLast(25))
+//These instance methods can also take the optional cancelCallback and readyCallback callbacks functions as
+//a third and fourth arguments.
+//Example of using readyCallback:
+vm.$bindAsObject('user', myFirebaseRef.child('user'), null, function () {})
 
 // References are unbinded when the component is destroyed but you can manually unbind a reference
 // if needed


### PR DESCRIPTION
With an short example to remind of using 'null' as a third argument if only readyCallback is wanted.