### PR TITLE
Fixing inconsistent variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ## Usage
 
 ``` js
-var firebaseApp = firebase.initializeApp({ ... })
+var firebaseApp = Firebase.initializeApp({ ... })
 var db = firebaseApp.database()
 
 var vm = new Vue({


### PR DESCRIPTION
in the installation section it is
`var Firebase = require('firebase')`
while in the usage section it is
`var firebaseApp = firebase.initializeApp({ ... })`
it should be
`var firebaseApp = Firebase.initializeApp({ ... })`