### PR TITLE
Pass through Date objects unscathed

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -27,6 +27,8 @@ export function extractRefs (doc, oldDoc, path = '', result = [{}, {}]) {
       // TODO handle array
       tot[0][key] = Array(ref.length).fill(null)
       extractRefs(ref, oldDoc[key], path + key + '.', [tot[0][key], tot[1]])
+    } else if (ref instanceof Date) {
+      tot[0][key] = ref
     } else if (isObject(ref)) {
       tot[0][key] = {}
       extractRefs(ref, oldDoc[key], path + key + '.', [tot[0][key], tot[1]])

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -54,6 +54,17 @@ test('extract refs from document', () => {
   })
 })
 
+test('leave Date objects alone when extracting refs', () => {
+  const d = new Date()
+  const [doc, refs] = extractRefs({
+    foo: 1,
+    bar: d
+  })
+  expect(doc.foo).toEqual(1)
+  expect(doc.bar).toEqual(d)
+  expect(refs).toEqual({})
+})
+
 test('extract object nested refs from document', () => {
   const [noRefsDoc, refs] = extractRefs({
     obj: {


### PR DESCRIPTION
Firestore has native support for timestamps, which show up in JS as `Date` objects. We need a special case in `extractRefs` because recursing into a `Date` and copying its fields doesn't produce a proper copy. Instead we should pass it through the same way we do with more fundamental types, like strings or numbers.