### PR TITLE
extractRefs now checks ref.constructor.name

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,7 @@ export function extractRefs (doc, oldDoc, path = '', result = [{}, {}]) {
   return Object.keys(doc).reduce((tot, key) => {
     const ref = doc[key]
     // if it's a ref
-    if (ref && typeof ref.isEqual === 'function') {
+    if (ref && typeof ref.isEqual === 'function' && ref.constructor.name === 'DocumentReference') {
       tot[0][key] = oldDoc[key] || ref.path
       // TODO handle subpathes?
       tot[1][path + key] = ref


### PR DESCRIPTION
Possible fix for #181 

Hey, I debugged the code a little and came up with this. It seems to do the trick in my app running in chrome. Maybe if you think this is going in the right direction the check for `ref.isEqual` could be omitted in the first place?

I'm really no js expert, so I can't say if checking ref.constructor.name is a good idea.

By checking ref.constructor.name === 'DocumentReference', we can avoid
mistakingly handling Timestamp objects (which also have an isEqual
method) as references.

What do you think?