### PR TITLE
fix(vuexfire): Correct main/module/browser entries

### DIFF
--- a/packages/vuexfire/package.json
+++ b/packages/vuexfire/package.json
@@ -2,10 +2,10 @@
   "name": "vuexfire",
   "version": "3.0.0-alpha.8",
   "description": "Firestore binding for Vuex",
-  "main": "dist/vuexfire.cjs.js",
-  "module": "dist/vuexfire.es.js",
+  "main": "dist/vuexfire.common.js",
+  "module": "dist/vuexfire.esm.js",
   "unpkg": "dist/vuexfire.js",
-  "browser": "dist/vuexfire.es.js",
+  "browser": "dist/vuexfire.esm.js",
   "sideEffects": false,
   "files": [
     "src",


### PR DESCRIPTION
Hi! I attempted to update from `vuexfire@3.0.0-alpha.5` to `alpha.8` and began receiving this error in my project:

```
This dependency was not found:

* vuexfire in ./src/store/index.ts, ./src/store/login/actions.ts
```

It appears starting with `alpha.6`, the files in the `dist/` folder were named differently (ex: `vuexfire.cjs.js` became `vuexfire.common.js`), which breaks tools like Webpack and TypeScript.

This updates the entry points to reflect the files as they're published in NPM.