### PR TITLE
[VuexFire] Use firestore.Query instead of firestore.CollectionReference

### DIFF
--- a/packages/vuexfire/types/index.d.ts
+++ b/packages/vuexfire/types/index.d.ts
@@ -4,7 +4,7 @@ import { firestore } from 'firebase'
 export declare const firebaseMutations: MutationTree<any>
 
 interface FirebaseActionContext<S, R> extends ActionContext<S, R> {
-  bindFirebaseRef(key: string, ref: firestore.CollectionReference): Promise<firestore.DocumentData[]>
+  bindFirebaseRef(key: string, ref: firestore.Query): Promise<firestore.DocumentData[]>
   bindFirebaseRef(key: string, ref: firestore.DocumentReference): Promise<firestore.DocumentData>
   unbindFirebaseRef(key: string): void
 }

--- a/packages/vuexfire/types/test/index.ts
+++ b/packages/vuexfire/types/test/index.ts
@@ -4,11 +4,13 @@ import { firestore } from 'firebase'
 
 interface Payload {
   todos: firestore.CollectionReference
+  sortedTodos: firestore.Query
   user: firestore.DocumentReference
 }
 
 new Vuex.Store({
   state: {
+    sortedTodos: [], // Will be bound as an array
     todos: [], // Will be bound as an array
     user: null // Will be bound as an object
   },
@@ -22,6 +24,12 @@ new Vuex.Store({
       bindFirebaseRef('todos', payload.todos).then(todos => {
         todos.length
         commit('setTodosLoaded', true)
+      }).catch((err) => {
+        console.log(err)
+      })
+      bindFirebaseRef('sortedTodos', payload.sortedTodos).then(todos => {
+        todos.length
+        commit('setSortedTodosLoaded', true)
       }).catch((err) => {
         console.log(err)
       })
@@ -40,6 +48,7 @@ new Vuex.Store({
 
       const payload: Payload = {
         todos: db.collection('todos'),
+        sortedTodos: db.collection('todos').orderBy('createdAt'),
         user: db.doc('user')
       }
 


### PR DESCRIPTION
To fix type errors for binding a collection with `where`, `order`, `limit`, and so on.
`firestore.CollectionReference` extends `firestore.Query` and `firestore.Query` is more appropriate as `bindFirebaseRef` is not dependent on the interface extended by `firestore.CollectionReference`.