### PR TITLE
Fix loss of nested references on documents when binding a collection in Vuexfire

### DIFF
--- a/packages/vuexfire/src/index.js
+++ b/packages/vuexfire/src/index.js
@@ -86,7 +86,7 @@ export function firebaseAction (action) {
       remove: (target, oldIndex) => {
         const data = target[oldIndex]
         commit(VUEXFIRE_ARRAY_REMOVE, { target, oldIndex }, commitOptions)
-        return data
+        return [data]
       }
     }
 


### PR DESCRIPTION
Hey! I was having trouble with getting nested references populated on documents in a collection using `vuexfire`. It works completely fine on the initial binding, but any changes to the document seems to discard any other unmodified references.

Here's an example:

```js
Article {
  title: 'Cool story',
  author: { // Reference to a user document
    id: 'someUserId',
    name: 'Renowned writer'
  },
  body: 'Good words',
  comments: [ // List of references to comment documents
    {
      id: 'someCommentId',
      text: 'Wow that was good stuff'
    },
    {
      id: 'someOtherCommentId',
      text: 'Moved me to tears tbqh'
    }
  ]
}
```

If I update that document by with a new comment, any existing references are lost but the new one is populated. The end result looks something like this:

```js
Article {
  title: 'Cool story',
  author: 'users/someUserId', // Only the ref path remains
  body: 'Good words',
  comments: [
    'comments/someCommentId', // Same with these previous two
    'comments/someOtherCommentId',
    {
      id: 'yetAnotherCommentId',
      text: 'Computers stuff is hard'
    }
  ]
}
```

It's worth noting that this problem only seems to persist with bound collections. Your sorcery is strong, but I tried poking around myself and managed to find [this line in vuefire-core](https://github.com/vuejs/vuefire/blob/cbf754f8ad5b69192706fa290356f1409344d7c8/packages/%40posva/vuefire-core/src/index.js#L104):

Inside `bindCollection` there's a `change.modified` function and part of its logic (as far as I can tell) is leveraging the existing document object during state updates (maybe, I think, *sorcery*). It looks like a previous revision used `Array.splice` while later versions favor this `ops` convention established in `vuefire-core`:

```js
const oldData = ops.remove(array, oldIndex)[0]
```

This retains the expectation that the result from invoking `ops.remove` will return an array, however [`vuexfire`'s configuration](https://github.com/vuejs/vuefire/blob/cbf754f8ad5b69192706fa290356f1409344d7c8/packages/vuexfire/src/index.js#L89) returns an individual item.

I managed to get this working by wrapping that return in an array, although I don't know how "right" this is - I'm still new to most of these technologies. Hopefully I'm not too far off with this, what do you think?