### PR TITLE
feat: introduce support for setting a callback scheduler

### DIFF
--- a/packages/vuefire/src/index.js
+++ b/packages/vuefire/src/index.js
@@ -1,4 +1,4 @@
-import { bindCollection, bindDocument, walkSet } from '@posva/vuefire-core'
+import { bindCollection, bindDocument, setScheduler, walkSet } from '@posva/vuefire-core'
 export * from './rtdb'
 
 const ops = {
@@ -37,6 +37,10 @@ function bind ({ vm, key, ref, ops }, options = { maxRefDepth: 2 }) {
     }
     vm._firestoreUnbinds[key] = unbind
   })
+}
+
+export function setFirestoreScheduler (scheduler) {
+  setScheduler(scheduler)
 }
 
 export function firestorePlugin (Vue) {

--- a/packages/vuexfire/src/index.js
+++ b/packages/vuexfire/src/index.js
@@ -8,7 +8,7 @@ import {
 
 export * from './rtdb'
 
-import { bindCollection, bindDocument } from '@posva/vuefire-core'
+import { bindCollection, bindDocument, setScheduler } from '@posva/vuefire-core'
 export const vuexfireMutations = {}
 const commitOptions = { root: true }
 
@@ -69,6 +69,10 @@ function unbind ({ commit, key }) {
   // TODO dev check before
   sub[key]()
   delete sub[key]
+}
+
+export function setFirestoreScheduler (scheduler) {
+  setScheduler(scheduler)
 }
 
 export function firestoreAction (action) {


### PR DESCRIPTION
This changeset adds support for setting a scheduler to be used to execute the firestore changes.

The primary reason for this change is to allow a client to provide their own scheduler implementation, the default implementation being execute immediately.

This enables the user to come up with scheduling strategies, which may coalesce updates, to minimize the number of renders that need be performed for a large number of of document changes.

One such example is the following, that buffers all changes, to be released every 250ms.

    const callbackBuffer = []
    
    const flush = () => {
      while (callbackBuffer.length > 0) {
        callbackBuffer.pop()()
      }
    }
    
    window.setInterval(flush, 250)
    
    setFirestoreScheduler(f => {
      callbackBuffer.push(f)
    })