### PR TITLE
feat: add reset option

### DIFF
--- a/packages/@posva/vuefire-core/jest.config.js
+++ b/packages/@posva/vuefire-core/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: ['<rootDir>/src/*.js'],
+  collectCoverageFrom: ['<rootDir>/src/**/*.js'],
   testURL: 'http://localhost/'
 }

--- a/packages/@posva/vuefire-core/package.json
+++ b/packages/@posva/vuefire-core/package.json
@@ -22,11 +22,11 @@
     "url": "git+https://github.com/vuejs/vuefire.git"
   },
   "scripts": {
-    "pretest": "npm run lint",
-    "test": "npm run unit",
-    "unit": "jest",
+    "pretest": "yarn run lint",
+    "test": "yarn run test:unit",
+    "test:unit": "jest",
     "lint": "eslint --fix src test",
-    "dev": "npm run unit -- --watchAll"
+    "dev": "yarn run test:unit -- --watchAll"
   },
   "bugs": {
     "url": "https://github.com/vuejs/vuefire/issues"

--- a/packages/@posva/vuefire-core/src/index.js
+++ b/packages/@posva/vuefire-core/src/index.js
@@ -181,6 +181,7 @@ export function bindCollection (
     if (!docChanges.length) resolve()
   }, reject)
 
+  // TODO: we could allow an argument to unbind to override reset
   return () => {
     unbind()
     if (options.reset !== false) {

--- a/packages/@posva/vuefire-core/src/rtdb.js
+++ b/packages/@posva/vuefire-core/src/rtdb.js
@@ -1,6 +1,12 @@
 import { createRecordFromRTDBSnapshot, indexForKey } from './utils'
 
-export function rtdbBindAsObject ({ vm, key, document, resolve, reject, ops }) {
+const DEFAULT_OPTIONS = { reset: true }
+
+export function rtdbBindAsObject (
+  { vm, key, document, resolve, reject, ops },
+  options = DEFAULT_OPTIONS
+) {
+  options = Object.assign({}, DEFAULT_OPTIONS, options)
   const listener = document.on(
     'value',
     snapshot => {
@@ -12,10 +18,18 @@ export function rtdbBindAsObject ({ vm, key, document, resolve, reject, ops }) {
 
   return () => {
     document.off('value', listener)
+    if (options.reset !== false) {
+      const value = typeof options.reset === 'function' ? options.reset() : null
+      ops.set(vm, key, value)
+    }
   }
 }
 
-export function rtdbBindAsArray ({ vm, key, collection, resolve, reject, ops }) {
+export function rtdbBindAsArray (
+  { vm, key, collection, resolve, reject, ops },
+  options = DEFAULT_OPTIONS
+) {
+  options = Object.assign({}, DEFAULT_OPTIONS, options)
   const array = []
   ops.set(vm, key, array)
 
@@ -66,5 +80,9 @@ export function rtdbBindAsArray ({ vm, key, collection, resolve, reject, ops }) 
     collection.off('child_changed', childChanged)
     collection.off('child_removed', childRemoved)
     collection.off('child_moved', childMoved)
+    if (options.reset !== false) {
+      const value = typeof options.reset === 'function' ? options.reset() : []
+      ops.set(vm, key, value)
+    }
   }
 }

--- a/packages/@posva/vuefire-core/test/document.spec.js
+++ b/packages/@posva/vuefire-core/test/document.spec.js
@@ -31,7 +31,10 @@ describe('documents', () => {
     expect(ops.remove).not.toHaveBeenCalled()
     await document.update({ bar: 'bar' })
     expect(ops.set).toHaveBeenCalledTimes(2)
-    expect(ops.set).toHaveBeenLastCalledWith(vm, 'item', { bar: 'bar', foo: 'foo' })
+    expect(ops.set).toHaveBeenLastCalledWith(vm, 'item', {
+      bar: 'bar',
+      foo: 'foo'
+    })
   })
 
   it('adds non-enumerable id', async () => {
@@ -88,5 +91,47 @@ describe('documents', () => {
     })
     await promise
     expect(vm.item).toEqual({ foo: 'foo' })
+  })
+
+  it('resets the value when unbinding', async () => {
+    await document.update({ foo: 'foo' })
+    let unbind
+    const promise = new Promise((resolve, reject) => {
+      unbind = bindDocument({ vm, document, key: 'item', resolve, reject, ops })
+    })
+    await promise
+    expect(vm.item).toEqual({ foo: 'foo' })
+    unbind()
+    expect(vm.item).toEqual(null)
+  })
+
+  it('can be left as is', async () => {
+    await document.update({ foo: 'foo' })
+    let unbind
+    const promise = new Promise((resolve, reject) => {
+      unbind = bindDocument(
+        { vm, document, key: 'item', resolve, reject, ops },
+        { reset: false }
+      )
+    })
+    await promise
+    expect(vm.item).toEqual({ foo: 'foo' })
+    unbind()
+    expect(vm.item).toEqual({ foo: 'foo' })
+  })
+
+  it('can be reset to a specific value', async () => {
+    await document.update({ foo: 'foo' })
+    let unbind
+    const promise = new Promise((resolve, reject) => {
+      unbind = bindDocument(
+        { vm, document, key: 'item', resolve, reject, ops },
+        { reset: () => ({ bar: 'bar' }) }
+      )
+    })
+    await promise
+    expect(vm.item).toEqual({ foo: 'foo' })
+    unbind()
+    expect(vm.item).toEqual({ bar: 'bar' })
   })
 })

--- a/packages/@posva/vuefire-core/test/rtdb/as-array.spec.js
+++ b/packages/@posva/vuefire-core/test/rtdb/as-array.spec.js
@@ -139,4 +139,46 @@ describe('RTDB collection', () => {
     collection.flush()
     expect(vm.items).toEqual([{ name: 'bar' }])
   })
+
+  it('resets the value when unbinding', () => {
+    collection.push({ name: 'foo' })
+    collection.flush()
+    expect(vm.items).toEqual([{ name: 'foo' }])
+    unbind()
+    expect(vm.items).toEqual([])
+  })
+
+  it('can be left as is', async () => {
+    let unbind
+    const promise = new Promise((resolve, reject) => {
+      unbind = rtdbBindAsArray(
+        { vm, collection, key: 'itemsReset', resolve, reject, ops },
+        { reset: false }
+      )
+      collection.flush()
+    })
+    await promise
+    collection.push({ foo: 'foo' })
+    collection.flush()
+    expect(vm.itemsReset).toEqual([{ foo: 'foo' }])
+    unbind()
+    expect(vm.itemsReset).toEqual([{ foo: 'foo' }])
+  })
+
+  it('can be reset to a specific value', async () => {
+    let unbind
+    const promise = new Promise((resolve, reject) => {
+      unbind = rtdbBindAsArray(
+        { vm, collection, key: 'itemsReset', resolve, reject, ops },
+        { reset: () => [{ bar: 'bar' }] }
+      )
+      collection.flush()
+    })
+    await promise
+    collection.push({ foo: 'foo' })
+    collection.flush()
+    expect(vm.itemsReset).toEqual([{ foo: 'foo' }])
+    unbind()
+    expect(vm.itemsReset).toEqual([{ bar: 'bar' }])
+  })
 })

--- a/packages/@posva/vuefire-test-helpers/src/index.js
+++ b/packages/@posva/vuefire-test-helpers/src/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import { MockFirebase } from 'firebase-mock'
 
 Vue.config.productionTip = false
+Vue.config.devtools = false
 export { Vue, MockFirebase }
 
 export * from './mock'

--- a/packages/documentation/docs/api/vuefire.md
+++ b/packages/documentation/docs/api/vuefire.md
@@ -119,6 +119,7 @@ export default {
 Object that can contain the following properties:
 
 - `maxRefDepth`: How many levels of nested references should be automatically bound. Defaults to 2, meaning that References inside of References inside of documents bound with `bindFirestoreRef` will automatically be bound too.
+- `reset`: Allows to define the behavior when a reference is unbound. Defaults to `true`, which resets the property in the vue instance to `null` for documents and to an empty array `[]` for collections. It can also be set to a function returning a value to customize the value set. Setting it to `false` will keep the data as-is when unbounding.
 
 ## \$unbind
 
@@ -221,7 +222,7 @@ This method is only available after [installing `rtdbPlugin`](#rtdbplugin)
 
 `$rtdbBind` allows you to programatically bind a Reference or query to an **existing property** (created in `data`). It is called for you when you use the [`firebase` option](#firebase-option):
 
-`this.$rtdbBind(key: string, reference: Referenc | Query, options?): Promise<Object | Array>`
+`this.$rtdbBind(key: string, reference: Reference | Query, options?): Promise<Object | Array>`
 
 Depending on the type of the property, the Reference or Query will be bound as an array or as an object.
 
@@ -248,6 +249,12 @@ export default {
 ```
 
 `$rtdbBind` returns a Promise that is resolved once the data has been retrieved and synced into the state.
+
+#### `options`
+
+Object that can contain the following properties:
+
+- `reset`: Allows to define the behavior when a reference is unbound. Defaults to `true`, which resets the property in the vue instance to `null` for properties bound as objects and to an empty array `[]` for properties bound as arrays. It can also be set to a function returning a value to customize the value set. Setting it to `false` will keep the data as-is when unbounding.
 
 ## \$rtdbUnbind
 

--- a/packages/documentation/docs/api/vuexfire.md
+++ b/packages/documentation/docs/api/vuexfire.md
@@ -61,12 +61,13 @@ Returns a Promise that is resolved once the data has been _completely_ fetched a
 Can contain the following properties:
 
 - `maxRefDepth`: How many levels of nested references should be automatically bound. Defaults to 2, meaning that References inside of References inside of documents bound with `bindFirestoreRef` will automatically be bound too.
+- `reset`: Allows to define the behavior when a reference is unbound. Defaults to `true`, which resets the property in the vue instance to `null` for documents and to an empty array `[]` for collections. It can also be set to a function returning a value to customize the value set. Setting it to `false` will keep the data as-is when unbounding.
 
 ### unbindFirestoreRef
 
 `unbindFirestoreRef(key: string): void`
 
-Unsubscribes from updates for a given key. Leaves the state as-is.
+Unsubscribes from updates for a given key.
 
 ## firebaseAction
 
@@ -86,15 +87,21 @@ export const setDocument = firebaseAction(
 
 ### bindFirebaseRef
 
-- `bindFirebaseRef(key: string, ref: Query): Promise<Object[]>`
-- `bindFirebaseRef(key: string, ref: Document): Promise<Object>`
+- `bindFirebaseRef(key: string, ref: Query, options?): Promise<Object[]>`
+- `bindFirebaseRef(key: string, ref: Reference, options?): Promise<Object>`
 
-Binds a collection, Query or Document to a property previously declared in the state, relatively to the module we are on. It unbinds any previouly bound reference with the same `key`. If the current value in the state is an Array, it binds the data as an array, otherwise it binds it as an object.
+Binds a collection, Query or Reference to a property previously declared in the state, relatively to the module we are on. It unbinds any previouly bound reference with the same `key`. If the current value in the state is an Array, it binds the data as an array, otherwise it binds it as an object.
 
 Returns a promise that is resolved once the data is fetched and the state is in sync.
+
+#### `options`
+
+Can contain the following properties:
+
+- `reset`: Allows to define the behavior when a reference is unbound. Defaults to `true`, which resets the property in the vue instance to `null` for properties bound as objects and to an empty array `[]` for properties bound as arrays. It can also be set to a function returning a value to customize the value set. Setting it to `false` will keep the data as-is when unbounding.
 
 ### unbindFirebaseRef
 
 `unbindFirebaseRef(key: string): void`
 
-Unsubscribes from updates for a given key. Leaves the state as-is.
+Unsubscribes from updates for a given key.

--- a/packages/documentation/docs/vuefire/binding-subscriptions.md
+++ b/packages/documentation/docs/vuefire/binding-subscriptions.md
@@ -339,10 +339,47 @@ this.$unbind('documents')
 
 </FirebaseExample>
 
-Vuefire will **leave the data as-is**, if you want to reset it back to something is up to you to do so:
+By default, Vuefire **will reset** the property, you can customize this behaviour with the [`reset` option](../api/vuefire.md#options-2):
+
+<FirebaseExample>
 
 ```js
-// after calling `$rtdbUnbind` or `$unbind` on 'user' and 'documents'
-this.user = null
-this.documents = []
+// default behavior
+this.$rtdbBind('user')
+this.$rtdbUnbind('user')
+// this.user === null
+// using a boolean value for reset
+this.$rtdbBind('user', { reset: false })
+this.$rtdbUnbind('user')
+// this.user === { name: 'Eduardo' }
+// using the function syntax
+this.$rtdbBind('user', { reset: () => ({ name: 'unregistered' }) })
+this.$rtdbUnbind('user')
+
+// for references bound as arrays, they are reset to an empty array by default instead of `null`
+this.$rtdbBind('documents')
+this.$rtdbUnbind('documents')
+// this.documents === []
 ```
+
+```js
+// default behavior
+this.$bind('user')
+this.$unbind('user')
+// this.user === null
+// using a boolean value for reset
+this.$bind('user', { reset: false })
+this.$unbind('user')
+// this.user === { name: 'Eduardo' }
+// using the function syntax
+this.$bind('user', { reset: () => ({ name: 'unregistered' }) })
+this.$unbind('user')
+// this.user === { name: 'unregistered' }
+
+// for collections, they are reset to an empty array by default instead of `null`
+this.$bind('documents')
+this.$unbind('documents')
+// this.documents === []
+```
+
+</FirebaseExample>

--- a/packages/documentation/docs/vuexfire/binding-subscriptions.md
+++ b/packages/documentation/docs/vuexfire/binding-subscriptions.md
@@ -100,7 +100,73 @@ export default new Vuex.Store({
 }
 ```
 
-When unbinding, there is no need to wait for a promise, all listeners are teared down and the data remains intact, that means **it will keep the last value**. If you want to change that, you can `commit` a mutation to change the value
+</FirebaseExample>
+
+When unbinding, there is no need to wait for a promise, all listeners are teared down. By default, data **will be reset**, you can customize this behaviour with the [`reset` option](../api/vuefire.md#options-2):
+
+<FirebaseExample>
+
+```js
+// store.js
+export default new Vuex.Store({
+  // other store options are omitted for simplicity reasons
+
+  actions: {
+    someAction: firebaseAction(({ state, bindFirebaseRef unbindFirebaseRef }) => {
+      bindFirebaseRef('todos', db.ref('todos'))
+      unbindFirebaseRef('todos')
+      // state.todos === []
+
+      // using the boolean version
+      bindFirebaseRef('todos', db.ref('todos'), { reset: false })
+      unbindFirebaseRef('todos')
+      // state.todos === [{ text: 'Use Firestore Refs' }]
+
+      // using the function syntax
+      bindFirebaseRef('todos', db.ref('todos'), { reset: () => [{ text: 'placeholder' }] })
+      unbindFirebaseRef('todos')
+      // state.todos === [{ text: 'placeholder' }]
+
+      // documents are reset to null instead, you can also provide the same options as above
+      bindFirebaseRef('doc', db.ref('documents/1'))
+      unbindFirebaseRef('doc')
+      // state.doc === null
+
+    })
+  }
+}
+```
+
+```js
+// store.js
+export default new Vuex.Store({
+  // other store options are omitted for simplicity reasons
+
+  actions: {
+    someAction: firestoreAction(({ state, bindFirestoreRef unbindFirestoreRef }) => {
+      bindFirestoreRef('todos', db.collection('todos'))
+      unbindFirestoreRef('todos')
+      // state.todos === []
+
+      // using the boolean version
+      bindFirestoreRef('todos', db.collection('todos'), { reset: false })
+      unbindFirestoreRef('todos')
+      // state.todos === [{ text: 'Use Firestore Refs' }]
+
+      // using the function syntax
+      bindFirestoreRef('todos', db.collection('todos'), { reset: () => [{ text: 'placeholder' }] })
+      unbindFirestoreRef('todos')
+      // state.todos === [{ text: 'placeholder' }]
+
+      // documents are reset to null instead, you can also provide the same options as above
+      bindFirestoreRef('doc', db.collection('documents').doc('1'))
+      unbindFirestoreRef('doc')
+      // state.doc === null
+
+    })
+  }
+}
+```
 
 </FirebaseExample>
 

--- a/packages/vuefire/jest.config.js
+++ b/packages/vuefire/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: ['<rootDir>/src/*.js'],
+  collectCoverageFrom: ['<rootDir>/src/**/*.js'],
   testURL: 'http://localhost/'
 }

--- a/packages/vuefire/package.json
+++ b/packages/vuefire/package.json
@@ -16,13 +16,13 @@
   ],
   "scripts": {
     "lint": "eslint --color --ext=js,html src test examples",
-    "pretest": "npm run lint",
-    "test": "npm run build && npm run types && npm run test:unit",
+    "pretest": "yarn run lint",
+    "test": "yarn run build && yarn run types && yarn run test:unit",
     "test:unit": "jest",
     "types": "tsc -p ./types/test/tsconfig.json",
-    "dev": "npm run test:unit -- --watchAll",
+    "dev": "yarn run test:unit -- --watchAll",
     "build": "node --eval 'require(\"@posva/vuefire-bundler\")(\"Vuefire\")'",
-    "postversion": "npm run build"
+    "postversion": "yarn run build"
   },
   "repository": {
     "type": "git",

--- a/packages/vuefire/package.json
+++ b/packages/vuefire/package.json
@@ -20,7 +20,7 @@
     "test": "npm run build && npm run types && npm run test:unit",
     "test:unit": "jest",
     "types": "tsc -p ./types/test/tsconfig.json",
-    "dev": "npm run unit -- --watchAll",
+    "dev": "npm run test:unit -- --watchAll",
     "build": "node --eval 'require(\"@posva/vuefire-bundler\")(\"Vuefire\")'",
     "postversion": "npm run build"
   },

--- a/packages/vuefire/src/index.js
+++ b/packages/vuefire/src/index.js
@@ -7,7 +7,7 @@ const ops = {
   remove: (array, index) => array.splice(index, 1)
 }
 
-function bind ({ vm, key, ref, ops }, options = { maxRefDepth: 2 }) {
+function bind ({ vm, key, ref, ops }, options) {
   return new Promise((resolve, reject) => {
     let unbind
     if (ref.where) {

--- a/packages/vuefire/src/rtdb.js
+++ b/packages/vuefire/src/rtdb.js
@@ -25,27 +25,33 @@ const ops = {
   remove: (array, index) => array.splice(index, 1)
 }
 
-function bind (vm, key, source) {
+function bind (vm, key, source, options) {
   return new Promise((resolve, reject) => {
     let unbind
     if (Array.isArray(vm[key])) {
-      unbind = bindAsArray({
-        vm,
-        key,
-        collection: source,
-        resolve,
-        reject,
-        ops
-      })
+      unbind = bindAsArray(
+        {
+          vm,
+          key,
+          collection: source,
+          resolve,
+          reject,
+          ops
+        },
+        options
+      )
     } else {
-      unbind = bindAsObject({
-        vm,
-        key,
-        document: source,
-        resolve,
-        reject,
-        ops
-      })
+      unbind = bindAsObject(
+        {
+          vm,
+          key,
+          document: source,
+          resolve,
+          reject,
+          ops
+        },
+        options
+      )
     }
     vm._firebaseUnbinds[key] = unbind
   })
@@ -90,12 +96,12 @@ export function rtdbPlugin (
     }
   })
 
-  Vue.prototype[bindName] = function rtdbBind (key, source) {
+  Vue.prototype[bindName] = function rtdbBind (key, source, options) {
     if (this._firebaseUnbinds[key]) {
       this[unbindName](key)
     }
 
-    const promise = bind(this, key, source)
+    const promise = bind(this, key, source, options)
     this._firebaseSources[key] = source
     this.$firebaseRefs[key] = getRef(source)
 

--- a/packages/vuefire/test/rtdb/bind.spec.js
+++ b/packages/vuefire/test/rtdb/bind.spec.js
@@ -75,6 +75,6 @@ describe('RTDB: manual bind', () => {
     expect(vm.item).toEqual({ name: 'foo' })
     vm.$rtdbUnbind('item')
     source.set({ name: 'bar' })
-    expect(vm.item).toEqual({ name: 'foo' })
+    expect(vm.item).toEqual(null)
   })
 })

--- a/packages/vuefire/types/test/index.ts
+++ b/packages/vuefire/types/test/index.ts
@@ -48,6 +48,15 @@ app.$bind('document', db.collection('todos').doc('1')).then(doc => {
 app.$bind('document', db.collection('todos').doc('1'), { maxRefDepth: 2 })
 // empty option
 app.$bind('document', db.collection('todos').doc('1'), {})
+app.$bind('document', db.collection('todos').doc('1'), { reset: false })
+app.$bind('document', db.collection('todos').doc('1'), {
+  reset: () => ({ foo: 'foo' })
+})
+app.$rtdbBind('document', source, {})
+app.$rtdbBind('document', source, { reset: false })
+app.$rtdbBind('document', source, {
+  reset: () => ({ foo: 'foo' })
+})
 
 app.$rtdbBind('document', source).then(doc => {
   doc.val()

--- a/packages/vuefire/types/vue.d.ts
+++ b/packages/vuefire/types/vue.d.ts
@@ -7,6 +7,11 @@ import { firestore, database } from 'firebase'
 
 export interface BindFirestoreRefOptions {
   maxRefDepth?: number
+  reset?: boolean | (() => any)
+}
+
+export interface BindRTDBRefOptions {
+  reset?: boolean | (() => any)
 }
 
 declare module 'vue/types/vue' {
@@ -32,7 +37,8 @@ declare module 'vue/types/vue' {
 
     $rtdbBind(
       name: string,
-      reference: database.Reference | database.Query
+      reference: database.Reference | database.Query,
+      options?: BindRTDBRefOptions
     ): Promise<database.DataSnapshot>
     $rtdbUnbind: (name: string) => void
     $firebaseRefs: Readonly<Record<string, database.Reference>>

--- a/packages/vuexfire/jest.config.js
+++ b/packages/vuexfire/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: ['<rootDir>/src/*.js'],
+  collectCoverageFrom: ['<rootDir>/src/**/*.js'],
   testURL: 'http://localhost/'
 }

--- a/packages/vuexfire/package.json
+++ b/packages/vuexfire/package.json
@@ -16,13 +16,13 @@
   ],
   "scripts": {
     "lint": "eslint --color --ext=js,html src test examples",
-    "pretest": "npm run lint",
-    "test": "npm run build && npm run types && npm run test:unit",
+    "pretest": "yarn run lint",
+    "test": "yarn run build && yarn run types && yarn run test:unit",
     "test:unit": "jest",
-    "dev": "npm run test:unit -- --watchAll",
+    "dev": "yarn run test:unit -- --watchAll",
     "types": "tsc -p ./types/test/tsconfig.json",
     "build": "node --eval 'require(\"@posva/vuefire-bundler\")(\"Vuexfire\")'",
-    "postversion": "npm run build"
+    "postversion": "yarn run build"
   },
   "repository": {
     "type": "git",

--- a/packages/vuexfire/src/index.js
+++ b/packages/vuexfire/src/index.js
@@ -97,7 +97,7 @@ export function firestoreAction (action) {
       }
     }
 
-    context.bindFirestoreRef = (key, ref, options = { maxRefDepth: 2 }) =>
+    context.bindFirestoreRef = (key, ref, options) =>
       bind({ state, commit, key, ref, ops }, options)
     context.unbindFirestoreRef = key => unbind({ commit, key })
     return action(context, payload)

--- a/packages/vuexfire/src/rtdb/index.js
+++ b/packages/vuexfire/src/rtdb/index.js
@@ -11,7 +11,7 @@ const commitOptions = { root: true }
 // Firebase binding
 const subscriptions = new WeakMap()
 
-function bind ({ state, commit, key, ref, ops }) {
+function bind ({ state, commit, key, ref, ops }, options) {
   // TODO check ref is valid
   // TODO check defined in state
   let sub = subscriptions.get(commit)
@@ -27,22 +27,28 @@ function bind ({ state, commit, key, ref, ops }) {
 
   return new Promise((resolve, reject) => {
     sub[key] = Array.isArray(state[key])
-      ? rtdbBindAsArray({
-        vm: state,
-        key,
-        collection: ref,
-        ops,
-        resolve,
-        reject
-      })
-      : rtdbBindAsObject({
-        vm: state,
-        key,
-        document: ref,
-        ops,
-        resolve,
-        reject
-      })
+      ? rtdbBindAsArray(
+        {
+          vm: state,
+          key,
+          collection: ref,
+          ops,
+          resolve,
+          reject
+        },
+        options
+      )
+      : rtdbBindAsObject(
+        {
+          vm: state,
+          key,
+          document: ref,
+          ops,
+          resolve,
+          reject
+        },
+        options
+      )
   })
 }
 
@@ -80,8 +86,8 @@ export function firebaseAction (action) {
       }
     }
 
-    context.bindFirebaseRef = (key, ref) =>
-      bind({ state, commit, key, ref, ops })
+    context.bindFirebaseRef = (key, ref, options) =>
+      bind({ state, commit, key, ref, ops }, options)
     context.unbindFirebaseRef = key => unbind({ commit, key })
     return action(context, payload)
   }

--- a/packages/vuexfire/test/index.spec.js
+++ b/packages/vuexfire/test/index.spec.js
@@ -142,9 +142,9 @@ describe('firestoreAction', () => {
       unbindFirestoreRef('items')
     )
 
-    expect(store.state.items).toEqual([{ text: 'foo' }])
+    expect(store.state.items).toEqual([])
     await collection.add({ text: 'foo' })
-    expect(store.state.items).toEqual([{ text: 'foo' }])
+    expect(store.state.items).toEqual([])
     await setItems(collection)
     expect(store.state.items).toEqual([{ text: 'foo' }, { text: 'foo' }])
   })

--- a/packages/vuexfire/test/rtdb/index.spec.js
+++ b/packages/vuexfire/test/rtdb/index.spec.js
@@ -86,9 +86,9 @@ describe('RTDB: firebaseAction', () => {
       unbindFirebaseRef('items')
     )
 
-    expect(store.state.items).toEqual([{ text: 'foo' }])
+    expect(store.state.items).toEqual([])
     collection.push({ text: 'foo' })
-    expect(store.state.items).toEqual([{ text: 'foo' }])
+    expect(store.state.items).toEqual([])
     await setItems(collection)
     expect(store.state.items).toEqual([{ text: 'foo' }, { text: 'foo' }])
   })

--- a/packages/vuexfire/types/index.d.ts
+++ b/packages/vuexfire/types/index.d.ts
@@ -3,9 +3,10 @@ import { firestore } from 'firebase'
 
 export declare const vuexfireMutations: MutationTree<any>
 
-// TODO: could be refactor in vuefire-core
+// TODO: could be refactored in vuefire-core
 export interface BindFirestoreRefOptions {
   maxRefDepth?: number
+  reset?: boolean | (() => any)
 }
 
 interface FirestoreActionContext<S, R> extends ActionContext<S, R> {

--- a/packages/vuexfire/types/index.d.ts
+++ b/packages/vuexfire/types/index.d.ts
@@ -1,11 +1,15 @@
 import { MutationTree, ActionContext, Action } from 'vuex'
-import { firestore } from 'firebase'
+import { firestore, database } from 'firebase'
 
 export declare const vuexfireMutations: MutationTree<any>
 
 // TODO: could be refactored in vuefire-core
 export interface BindFirestoreRefOptions {
   maxRefDepth?: number
+  reset?: boolean | (() => any)
+}
+
+export interface BindRTDBRefOptions {
   reset?: boolean | (() => any)
 }
 
@@ -23,6 +27,19 @@ interface FirestoreActionContext<S, R> extends ActionContext<S, R> {
   unbindFirestoreRef(key: string): void
 }
 
+interface FirebaseActionContext<S, R> extends ActionContext<S, R> {
+  bindFirebaseRef(
+    key: string,
+    reference: database.Reference | database.Query,
+    options?: BindRTDBRefOptions
+  ): Promise<database.DataSnapshot>
+  unbindFirebaseRef(key: string): void
+}
+
 export declare function firestoreAction<S, R>(
-  cb: (context: FirestoreActionContext<S, R>, payload: any) => any
+  action: (context: FirestoreActionContext<S, R>, payload: any) => any
+): Action<S, R>
+
+export declare function firebaseAction<S, R>(
+  action: (context: FirebaseActionContext<S, R>, payload: any) => any
 ): Action<S, R>

--- a/packages/vuexfire/types/test/index.ts
+++ b/packages/vuexfire/types/test/index.ts
@@ -56,6 +56,14 @@ new Vuex.Store({
           })
           .catch(err => console.log(err))
 
+        bindFirestoreRef('todosWitMaxDepthZero', payload.todosWitMaxDepthZero, {
+          reset: false
+        })
+
+        bindFirestoreRef('todosWitMaxDepthZero', payload.todosWitMaxDepthZero, {
+          reset: () => ({ a: 'a' })
+        })
+
         bindFirestoreRef('user', payload.user).then(doc => {
           doc.something
         })
@@ -64,6 +72,7 @@ new Vuex.Store({
         unbindFirestoreRef('user')
       }
     )
+    // rtdb: rtdbA
   },
   plugins: [
     store => {

--- a/packages/vuexfire/types/test/index.ts
+++ b/packages/vuexfire/types/test/index.ts
@@ -1,12 +1,16 @@
 import Vuex from 'vuex'
-import { vuexfireMutations, firestoreAction } from '../'
-import { firestore } from 'firebase'
+import { vuexfireMutations, firestoreAction, firebaseAction } from '../'
+import { firestore, database } from 'firebase'
 
 interface Payload {
   todos: firestore.CollectionReference
   sortedTodos: firestore.Query
   todosWitMaxDepthZero: firestore.Query
   user: firestore.DocumentReference
+}
+interface RTDBPayload {
+  todos: database.Reference
+  sortedTodos: database.Query
 }
 
 new Vuex.Store({
@@ -71,8 +75,42 @@ new Vuex.Store({
         // you can unbind any ref easily
         unbindFirestoreRef('user')
       }
+    ),
+    rtdb: firebaseAction(
+      (
+        { bindFirebaseRef, unbindFirebaseRef, commit },
+        payload: RTDBPayload
+      ) => {
+        bindFirebaseRef('todos', payload.todos)
+          .then(todos => {
+            commit('setTodosLoaded', true)
+          })
+          .catch(err => {
+            console.log(err)
+          })
+        bindFirebaseRef('sortedTodos', payload.sortedTodos)
+          .then(todos => {
+            commit('setSortedTodosLoaded', true)
+          })
+          .catch(err => {
+            console.log(err)
+          })
+
+        // empty options
+        bindFirebaseRef('todosWitMaxDepthZero', payload.todos, {})
+
+        bindFirebaseRef('todosWitMaxDepthZero', payload.todos, {
+          reset: false
+        })
+
+        bindFirebaseRef('todosWitMaxDepthZero', payload.todos, {
+          reset: () => ({ a: 'a' })
+        })
+
+        // you can unbind any ref easily
+        unbindFirebaseRef('todos')
+      }
     )
-    // rtdb: rtdbA
   },
   plugins: [
     store => {


### PR DESCRIPTION
Closes #264 

BREAKING CHANGE: the default behavior is now resetting the data when unbinding. To keep the data as is, you have to provide a `reset: false` option