### PR TITLE
added firebase imports to docs

### DIFF
--- a/packages/documentation/docs/api/vuefire.md
+++ b/packages/documentation/docs/api/vuefire.md
@@ -5,11 +5,17 @@ For all code samples, we will consider a `db` variable is imported as follows:
 <FirebaseExample id="db creation">
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/database'
+
 // Get a RTDB instance
 const db = firebase.initializeApp({ databaseURL: 'MY PROJECT URL' }).database()
 ```
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/firestore'
+
 // Get a Firestore instance
 const db = firebase.initializeApp({ projectId: 'MY PROJECT ID' }).firestore()
 ```

--- a/packages/documentation/docs/api/vuexfire.md
+++ b/packages/documentation/docs/api/vuexfire.md
@@ -5,11 +5,17 @@ For all code samples, we will consider a `db` variable is imported as follows:
 <FirebaseExample id="db creation">
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/database'
+
 // Get a RTDB instance
 const db = firebase.initializeApp({ databaseURL: 'MY PROJECT URL' }).database()
 ```
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/firestore'
+
 // Get a Firestore instance
 const db = firebase.initializeApp({ projectId: 'MY PROJECT ID' }).firestore()
 ```

--- a/packages/documentation/docs/vuefire/README.md
+++ b/packages/documentation/docs/vuefire/README.md
@@ -10,6 +10,9 @@ While Firebase SDK does provide an API to keep your local data in sync with any 
 
 ```js
 // get RTDB the database instance
+import firebase from 'firebase/app'
+import 'firebase/database'
+
 const db = firebase
   .initializeApp({ databaseURL: 'https://MY-DATABASE.firebaseio.com' })
   .database()
@@ -88,6 +91,9 @@ new Vue({
 
 ```js
 // get Firestore database instance
+import firebase from 'firebase/app'
+import 'firebase/firestore'
+
 const db = firebase.initializeApp({ projectId: 'MY PROJECT ID' }).firestore()
 
 new Vue({
@@ -133,6 +139,9 @@ Now let's look at the equivalent code with vuefire:
 <FirebaseExample id="getting-started">
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/database'
+
 const db = firebase
   .initializeApp({ databaseURL: 'https://MY-DATABASE.firebaseio.com' })
   .database()
@@ -148,6 +157,9 @@ new Vue({
 ```
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/firestore'
+
 const db = firebase.initializeApp({ projectId: 'MY PROJECT ID' }).firestore()
 
 new Vue({

--- a/packages/documentation/docs/vuefire/getting-started.md
+++ b/packages/documentation/docs/vuefire/getting-started.md
@@ -50,12 +50,18 @@ You also need to get a database instance from firebase. This can be put into a `
 
 ```js
 // Get a RTDB instance
+import firebase from 'firebase/app'
+import 'firebase/database'
+
 export const db = firebase
   .initializeApp({ databaseURL: 'MY PROJECT URL' })
   .database()
 ```
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/firestore'
+
 // Get a Firestore instance
 export const db = firebase
   .initializeApp({ projectId: 'MY PROJECT ID' })

--- a/packages/documentation/docs/vuexfire/README.md
+++ b/packages/documentation/docs/vuexfire/README.md
@@ -9,6 +9,9 @@ While Firebase SDK does provide an API to keep your local data in sync with any 
 <FirebaseExample id="original">
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/database'
+
 // get RTDB the database instance
 const db = firebase
   .initializeApp({ databaseURL: 'https://MY-DATABASE.firebaseio.com' })
@@ -103,6 +106,9 @@ new Vuex.Store({
 ```
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/firestore'
+
 // get Firestore database instance
 const db = firebase.initializeApp({ projectId: 'MY PROJECT ID' }).firestore()
 
@@ -178,6 +184,8 @@ Now let's look at the equivalent code with Vuexfire:
 
 ```js
 import { vuexfireMutations, firebaseAction } from 'vuexfire'
+import firebase from 'firebase/app'
+import 'firebase/database'
 
 const db = firebase
   .initializeApp({ databaseURL: 'https://MY-DATABASE.firebaseio.com' })
@@ -205,6 +213,8 @@ new Vue.Store({
 
 ```js
 import { vuexfireMutations, firestoreAction } from 'vuexfire'
+import firebase from 'firebase/app'
+import 'firebase/firestore'
 
 const db = firebase.initializeApp({ projectId: 'MY PROJECT ID' }).firestore()
 

--- a/packages/documentation/docs/vuexfire/getting-started.md
+++ b/packages/documentation/docs/vuexfire/getting-started.md
@@ -43,6 +43,9 @@ You also need to get a database instance from firebase. This can be put into a `
 <FirebaseExample>
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/database'
+
 // Get a RTDB instance
 export const db = firebase
   .initializeApp({ databaseURL: 'MY PROJECT URL' })
@@ -50,6 +53,9 @@ export const db = firebase
 ```
 
 ```js
+import firebase from 'firebase/app'
+import 'firebase/firestore'
+
 // Get a Firestore instance
 export const db = firebase
   .initializeApp({ projectId: 'MY PROJECT ID' })


### PR DESCRIPTION
While going through the tutorial I was confused where `firebase` came from so I thought it would be helpful to add it to the examples. some of the other docs have imports so I thought these should also have them.