### PR TITLE
Old array elements are removed from binding

### DIFF
--- a/packages/@posva/vuefire-core/src/utils.js
+++ b/packages/@posva/vuefire-core/src/utils.js
@@ -65,8 +65,6 @@ export function extractRefs (doc, oldDoc = {}, path = '', result = [{}, {}]) {
       // TODO handle subpathes?
       refs[path + key] = ref
     } else if (Array.isArray(ref)) {
-      // const arrayExtractedRefs = ref.map(refItem => extractRefs())
-
       // TODO handle array
       data[key] = Array(ref.length).fill(null)
       const oldArray = oldDoc[key] || []

--- a/packages/@posva/vuefire-core/src/utils.js
+++ b/packages/@posva/vuefire-core/src/utils.js
@@ -56,17 +56,23 @@ export function extractRefs (doc, oldDoc = {}, path = '', result = [{}, {}]) {
   if (idDescriptor && !idDescriptor.enumerable) {
     Object.defineProperty(result[0], 'id', idDescriptor)
   }
-  return Object.keys(doc).reduce((tot, key) => {
+  const [data, refs] = result
+  for (const key in doc) {
     const ref = doc[key]
     // if it's a ref
     if (isRef(ref)) {
-      tot[0][key] = oldDoc[key] || ref.path
+      data[key] = oldDoc[key] || ref.path
       // TODO handle subpathes?
-      tot[1][path + key] = ref
+      refs[path + key] = ref
     } else if (Array.isArray(ref)) {
+      // const arrayExtractedRefs = ref.map(refItem => extractRefs())
+
       // TODO handle array
-      tot[0][key] = Array(ref.length).fill(null)
-      extractRefs(ref, oldDoc[key], path + key + '.', [tot[0][key], tot[1]])
+      data[key] = Array(ref.length).fill(null)
+      const oldArray = oldDoc[key] || []
+      // Items there are no longer in the array aren't going to be processed
+      const newElements = oldArray.filter(oldRef => ref.indexOf(oldRef) !== -1)
+      extractRefs(ref, newElements, path + key + '.', [data[key], refs])
     } else if (
       ref == null ||
       // Firestore < 4.13
@@ -74,15 +80,15 @@ export function extractRefs (doc, oldDoc = {}, path = '', result = [{}, {}]) {
       isTimestamp(ref) ||
       (ref.longitude && ref.latitude) // GeoPoint
     ) {
-      tot[0][key] = ref
+      data[key] = ref
     } else if (isObject(ref)) {
-      tot[0][key] = {}
-      extractRefs(ref, oldDoc[key], path + key + '.', [tot[0][key], tot[1]])
+      data[key] = {}
+      extractRefs(ref, oldDoc[key], path + key + '.', [data[key], refs])
     } else {
-      tot[0][key] = ref
+      data[key] = ref
     }
-    return tot
-  }, result)
+  }
+  return result
 }
 
 /**

--- a/packages/@posva/vuefire-core/src/utils.js
+++ b/packages/@posva/vuefire-core/src/utils.js
@@ -68,7 +68,7 @@ export function extractRefs (doc, oldDoc = {}, path = '', result = [{}, {}]) {
       // TODO handle array
       data[key] = Array(ref.length).fill(null)
       const oldArray = oldDoc[key] || []
-      // Items there are no longer in the array aren't going to be processed
+      // Items that are no longer in the array aren't going to be processed
       const newElements = oldArray.filter(oldRef => ref.indexOf(oldRef) !== -1)
       extractRefs(ref, newElements, path + key + '.', [data[key], refs])
     } else if (

--- a/packages/@posva/vuefire-core/test/refs-documents.spec.js
+++ b/packages/@posva/vuefire-core/test/refs-documents.spec.js
@@ -48,6 +48,17 @@ describe('refs in documents', () => {
     ops.remove.mockClear()
   })
 
+  it('item should be removed from binding when theres an arrays of refs', async () => {
+    const arr = collection.doc()
+    vm.arr = null
+
+    await arr.update({ refs: [a, b, c] })
+    await bind('arr', arr, { maxRefDepth: 0 })
+    await arr.update({ refs: [b, c] })
+
+    expect(vm.arr).toEqual({ refs: [b.path, c.path] })
+  })
+
   it('binds refs on documents', async () => {
     // create an empty doc and update using the ref instead of plain data
     await item.update({ ref: c })


### PR DESCRIPTION
Fixes #283 

I'm still confused about how this works, but it does pass the test.

Basically, when updating an array I discard all the old values that are no longer in the new document and pass it as the "oldDoc" to the recursive `extractRefs`.

It passed all the tests, but I don't know if it breaks anything untested, which is pretty hard to predict.

I also changed the `extractRefs` function to use `for in` instead of `reduce` and added 2 new variables
for the result indexes instead of accessing them manually every time