### PR TITLE
Update Firestore ordering method to use orderBy()

### DIFF
--- a/packages/documentation/docs/vuexfire/querying.md
+++ b/packages/documentation/docs/vuexfire/querying.md
@@ -75,7 +75,7 @@ RTDB and Cloudstore do not include the same set of features regarding sorting bu
     bindDocuments: firestoreAction(({ bindFirestoreRef }) => {
       return bindFirestoreRef(
         'documents',
-        db.collection('documents').orderByChild('createdAt')
+        db.collection('documents').orderBy('createdAt', 'desc')
       )
     })
   }


### PR DESCRIPTION
This firestore action made use of   db.ref('documents').orderByChild('createdAt') instead of db.collection('blogs').orderBy('created_at', 'desc') according to firestore documentation.