### PR TITLE
Removed unnecessary walkset imports when creating ops - Unit Tests Refactoring

### DIFF
--- a/packages/@posva/vuefire-core/__tests__/firestore/collection.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/firestore/collection.spec.ts
@@ -1,4 +1,4 @@
-import { bindCollection, walkSet } from '../../src'
+import { bindCollection } from '../../src'
 import { db, createOps, spyUnbind } from '@posva/vuefire-test-helpers'
 import { firestore } from 'firebase'
 import { OperationsType } from '../../src/shared'
@@ -14,7 +14,7 @@ describe('collections', () => {
     // @ts-ignore
     collection = db.collection()
     vm = {}
-    ops = createOps(walkSet)
+    ops = createOps()
     await new Promise((res, rej) => {
       resolve = jest.fn(res)
       reject = jest.fn(rej)

--- a/packages/@posva/vuefire-core/__tests__/firestore/document.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/firestore/document.spec.ts
@@ -1,4 +1,4 @@
-import { bindDocument, walkSet } from '../../src'
+import { bindDocument } from '../../src'
 import { db, spyUnbind, createOps } from '@posva/vuefire-test-helpers'
 import { firestore } from 'firebase'
 import { OperationsType } from '../../src/shared'
@@ -16,7 +16,7 @@ describe('documents', () => {
     collection = db.collection()
     // @ts-ignore
     document = collection.doc()
-    ops = createOps(walkSet)
+    ops = createOps()
     vm = {}
     await new Promise((res, rej) => {
       resolve = jest.fn(res)

--- a/packages/@posva/vuefire-core/__tests__/firestore/options.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/firestore/options.spec.ts
@@ -1,4 +1,4 @@
-import { bindDocument, walkSet, firestoreOptions, bindCollection } from '../../src'
+import { bindDocument, firestoreOptions, bindCollection } from '../../src'
 import { db, createOps, CollectionReference, DocumentReference } from '@posva/vuefire-test-helpers'
 import { firestore } from 'firebase'
 
@@ -8,7 +8,7 @@ describe('options', () => {
     vm: Record<string, any>,
     resolve: (data: any) => void,
     reject: (error: any) => void
-  const ops = createOps(walkSet)
+  const ops = createOps()
 
   beforeEach(async () => {
     // @ts-ignore

--- a/packages/@posva/vuefire-core/__tests__/firestore/refs-collections.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/firestore/refs-collections.spec.ts
@@ -1,4 +1,4 @@
-import { bindCollection, walkSet, FirestoreOptions } from '../../src'
+import { bindCollection, FirestoreOptions } from '../../src'
 import { db, delay, spyUnbind, delayUpdate, createOps } from '@posva/vuefire-test-helpers'
 import { OperationsType } from '../../src/shared'
 import { firestore } from 'firebase'
@@ -24,7 +24,7 @@ describe('refs in collections', () => {
       b: null,
       c: null,
     }
-    ops = createOps(walkSet)
+    ops = createOps()
     bind = (key, collection, options) => {
       return new Promise(
         (resolve, reject) =>

--- a/packages/@posva/vuefire-core/__tests__/firestore/refs-documents.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/firestore/refs-documents.spec.ts
@@ -1,4 +1,4 @@
-import { bindDocument, walkSet, FirestoreOptions } from '../../src'
+import { bindDocument, FirestoreOptions } from '../../src'
 import {
   db,
   delay,
@@ -34,7 +34,7 @@ describe('refs in documents', () => {
       b: null,
       c: null,
     }
-    ops = createOps(walkSet)
+    ops = createOps()
     // @ts-ignore
     collection = db.collection()
     // @ts-ignore

--- a/packages/@posva/vuefire-core/__tests__/rtdb/as-array.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/rtdb/as-array.spec.ts
@@ -1,4 +1,4 @@
-import { rtdbBindAsArray, walkSet } from '../../src'
+import { rtdbBindAsArray } from '../../src'
 import { MockFirebase, createOps, MockedReference } from '@posva/vuefire-test-helpers'
 
 describe('RTDB collection', () => {
@@ -7,7 +7,7 @@ describe('RTDB collection', () => {
     resolve: (data: any) => void,
     reject: (error: any) => void,
     unbind: () => void
-  const ops = createOps(walkSet)
+  const ops = createOps()
 
   beforeEach(async () => {
     collection = new MockFirebase().child('data')

--- a/packages/@posva/vuefire-core/__tests__/rtdb/as-object.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/rtdb/as-object.spec.ts
@@ -1,4 +1,4 @@
-import { rtdbBindAsObject, walkSet } from '../../src/index'
+import { rtdbBindAsObject } from '../../src/index'
 import { MockFirebase, MockedReference, createOps } from '@posva/vuefire-test-helpers'
 
 function createSnapshotFromPrimitive(value: any, key: string) {
@@ -14,7 +14,7 @@ describe('RTDB document', () => {
     resolve: (data: any) => void,
     reject: (error: any) => void,
     unbind: () => void
-  const ops = createOps(walkSet)
+  const ops = createOps()
 
   beforeEach(async () => {
     document = new MockFirebase().child('data')

--- a/packages/@posva/vuefire-core/__tests__/rtdb/options.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/rtdb/options.spec.ts
@@ -1,4 +1,4 @@
-import { walkSet, rtdbBindAsObject, rtdbBindAsArray, rtdbOptions } from '../../src'
+import { rtdbBindAsObject, rtdbBindAsArray, rtdbOptions } from '../../src'
 import { MockFirebase, createOps, MockedReference } from '@posva/vuefire-test-helpers'
 
 describe('RTDB options', () => {
@@ -6,7 +6,7 @@ describe('RTDB options', () => {
     document: MockedReference,
     vm: Record<string, any>,
     unbind: () => void
-  const ops = createOps(walkSet)
+  const ops = createOps()
   beforeEach(async () => {
     collection = new MockFirebase().child('data')
     document = new MockFirebase().child('data')

--- a/packages/@posva/vuefire-core/__tests__/shared.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/shared.spec.ts
@@ -1,7 +1,7 @@
 import { walkSet } from '../src'
 
 describe('test', () => {
-  it('works', () => {
+  it('walkset works', () => {
     expect(walkSet({ a: { b: true } }, 'a.b', 2)).toBe(2)
   })
 })

--- a/packages/@posva/vuefire-core/__tests__/shared.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/shared.spec.ts
@@ -1,7 +1,7 @@
 import { walkSet } from '../src'
 
-describe('test', () => {
-  it('walkset works', () => {
+describe('shared tools', () => {
+  it('simple walkset nested access', () => {
     expect(walkSet({ a: { b: true } }, 'a.b', 2)).toBe(2)
   })
 })

--- a/packages/@posva/vuefire-test-helpers/src/index.ts
+++ b/packages/@posva/vuefire-test-helpers/src/index.ts
@@ -71,8 +71,8 @@ export function delay(time: number) {
 }
 
 type WalkSet = typeof walkSet
-export const createOps = (walkSet: WalkSet) => ({
+export const createOps = (innerWalkSet: WalkSet = walkSet) => ({
   add: jest.fn((array, index, data) => array.splice(index, 0, data)),
-  set: jest.fn(walkSet),
+  set: jest.fn(innerWalkSet),
   remove: jest.fn((array, index) => array.splice(index, 1)),
 })

--- a/packages/@posva/vuefire-test-helpers/src/index.ts
+++ b/packages/@posva/vuefire-test-helpers/src/index.ts
@@ -71,8 +71,8 @@ export function delay(time: number) {
 }
 
 type WalkSet = typeof walkSet
-export const createOps = (innerWalkSet: WalkSet = walkSet) => ({
+export const createOps = () => ({
   add: jest.fn((array, index, data) => array.splice(index, 0, data)),
-  set: jest.fn(innerWalkSet),
+  set: jest.fn(walkSet),
   remove: jest.fn((array, index) => array.splice(index, 1)),
 })

--- a/packages/@posva/vuefire-test-helpers/src/index.ts
+++ b/packages/@posva/vuefire-test-helpers/src/index.ts
@@ -71,7 +71,7 @@ export function delay(time: number) {
 }
 
 type WalkSet = typeof walkSet
-export const createOps = (localWalkSet: WalkSet) => ({
+export const createOps = (localWalkSet: WalkSet = walkSet) => ({
   add: jest.fn((array, index, data) => array.splice(index, 0, data)),
   set: jest.fn(localWalkSet),
   remove: jest.fn((array, index) => array.splice(index, 1)),

--- a/packages/@posva/vuefire-test-helpers/src/index.ts
+++ b/packages/@posva/vuefire-test-helpers/src/index.ts
@@ -71,8 +71,8 @@ export function delay(time: number) {
 }
 
 type WalkSet = typeof walkSet
-export const createOps = () => ({
+export const createOps = (localWalkSet: WalkSet) => ({
   add: jest.fn((array, index, data) => array.splice(index, 0, data)),
-  set: jest.fn(walkSet),
+  set: jest.fn(localWalkSet),
   remove: jest.fn((array, index) => array.splice(index, 1)),
 })

--- a/packages/vuefire/src/index.ts
+++ b/packages/vuefire/src/index.ts
@@ -1,3 +1,2 @@
-export { walkSet } from '@posva/vuefire-core'
 export * from './rtdb'
 export * from './firestore'


### PR DESCRIPTION
I noticed that every time `createOps` is called, `walkSet` is imported in all spec files that use it.

This PR adds the default walkset as the default parameter, so there's no need to pass it every time `createOps` is called 