### PR TITLE
Example for One Time Read didn't work anymore

### DIFF
--- a/packages/documentation/docs/vuefire/querying.md
+++ b/packages/documentation/docs/vuefire/querying.md
@@ -27,7 +27,7 @@ db.ref('documents/' + documentId).once('value', snapshot => {
 db.collection('documents')
   .get()
   .then(querySnapshot => {
-    const documents = querySnapshot.map(doc => doc.data())
+    const documents = querySnapshot.docs.map(doc => doc.data())
     // do something with documents
   })
 


### PR DESCRIPTION
QuerySnapshot class doesn't have map function. docs property is always an array and works with map regardless if Firestore Query yields results or not.