### PR TITLE
Add 'wait' option to bindCollection

### DIFF
--- a/packages/@posva/vuefire-core/src/firestore/index.ts
+++ b/packages/@posva/vuefire-core/src/firestore/index.ts
@@ -362,7 +362,7 @@ export function bindDocument(
     unbind()
     const resetOption = reset === undefined ? options.reset : reset
     if (resetOption !== false) {
-      const value = typeof resetOption === 'function' ? resetOption() : []
+      const value = typeof resetOption === 'function' ? resetOption() : null
       ops.set(vm, key, value)
     }
     unsubscribeAll(subs)

--- a/packages/vuexfire/src/firestore.ts
+++ b/packages/vuexfire/src/firestore.ts
@@ -123,11 +123,20 @@ export function firestoreAction<S, R>(
         )
         return data
       },
-      add: (target, newIndex, data) =>
-        commit(VUEXFIRE_ARRAY_ADD, { target, newIndex, data }, commitOptions),
+      add: (target, newIndex, data) => {
+        if ('__ob__' in target) {
+          commit(VUEXFIRE_ARRAY_ADD, { target, newIndex, data }, commitOptions)
+        } else {
+          target[newIndex] = data
+        }
+      },
       remove: (target, oldIndex) => {
         const data = target[oldIndex]
-        commit(VUEXFIRE_ARRAY_REMOVE, { target, oldIndex }, commitOptions)
+        if ('__ob__' in target) {
+          commit(VUEXFIRE_ARRAY_REMOVE, { target, oldIndex }, commitOptions)
+        } else {
+          target.splice(oldIndex, 1)
+        }
         return [data]
       },
     }

--- a/packages/vuexfire/src/rtdb.ts
+++ b/packages/vuexfire/src/rtdb.ts
@@ -101,11 +101,20 @@ export function firebaseAction<S, R>(
         )
         return data
       },
-      add: (target, newIndex, data) =>
-        commit(VUEXFIRE_ARRAY_ADD, { target, newIndex, data }, commitOptions),
+      add: (target, newIndex, data) => {
+        if ('__ob__' in target) {
+          commit(VUEXFIRE_ARRAY_ADD, { target, newIndex, data }, commitOptions)
+        } else {
+          target[newIndex] = data
+        }
+      },
       remove: (target, oldIndex) => {
         const data = target[oldIndex]
-        commit(VUEXFIRE_ARRAY_REMOVE, { target, oldIndex }, commitOptions)
+        if ('__ob__' in target) {
+          commit(VUEXFIRE_ARRAY_REMOVE, { target, oldIndex }, commitOptions)
+        } else {
+          target.splice(oldIndex, 1)
+        }
         return [data]
       },
     }


### PR DESCRIPTION
This commit addresses some issues mentioned in topic https://github.com/vuejs/vuefire/issues/83.

This is by no means tried and tested, but thought I'd give it a start... will create a local array rather than a reference to the reactive prop, and only use .set() when populated.