### PR TITLE
Added test for user manual array manipulation in RTDB

### DIFF
--- a/packages/@posva/vuefire-core/__tests__/rtdb/as-array.spec.ts
+++ b/packages/@posva/vuefire-core/__tests__/rtdb/as-array.spec.ts
@@ -183,4 +183,13 @@ describe('RTDB collection', () => {
     unbind()
     expect(vm.itemsReset).toEqual([{ bar: 'bar' }])
   })
+
+  it('adds elements when user manually removes items', () => {
+    collection.push({ name: 'one' })
+    collection.flush()
+    collection.push({ name: 'two' })
+    vm.items.splice(0, 1)
+    collection.flush()
+    expect(vm.items).toEqual([{ name: 'two' }])
+  })
 })


### PR DESCRIPTION
I noticed that this line was not covered by tests:
https://github.com/vuejs/vuefire/blob/f2a981fef7665f08acf6aac777c5f110a652c1a3/packages/%40posva/vuefire-core/src/rtdb/utils.ts#L38

So I developed a test to mimic a user trying to manually remove an item of the array binding.
It shouldn't be a good idea to do that as a user, but now we can get 100% of lines coverage, and it's still a possible scenario.