### PR TITLE
Added ts path mapping between packages

### DIFF
--- a/packages/vuexfire/__tests__/options.spec.ts
+++ b/packages/vuexfire/__tests__/options.spec.ts
@@ -2,7 +2,7 @@ import Vuex from 'vuex'
 import { vuexfireMutations, firestoreAction } from '../src'
 import { db, tick, Vue } from '@posva/vuefire-test-helpers'
 import { firestore } from 'firebase'
-import { FirestoreOptions } from '@posva/vuefire-core/dist/packages/@posva/vuefire-core/src'
+import { FirestoreOptions } from '@posva/vuefire-core'
 
 Vue.use(Vuex)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
     "composite": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
-
+    "paths": {
+      "@posva/*": ["packages/@posva/*/src"]
+    },
     "rootDir": ".",
     "baseUrl": "."
   },


### PR DESCRIPTION
## What does this PR contain?
It just changes the `@posva` packages path to be mapped to the src instead of the declaration files generated by the build in the `dist` folder.

Before that, when ctrl clicking the package `@posva/vuefire-core` inside another package files, it
redirected to the dist folder. Now it goes to the src.

I also removed one import that was pointing to a dist folder inside the core package (idk why it was doing that).

## Motivation
It was really frustrating to look after the core files while debugging and end up in a declaration file. This should make the code flow easier to understand by ctrl clicking.

Edit:
I noticed that #384 should have its problem fixed too