### PR TITLE
Added support for this referencing inside firebase funcs

### DIFF
--- a/packages/vuefire/src/firestore.ts
+++ b/packages/vuefire/src/firestore.ts
@@ -8,6 +8,7 @@ import {
 } from '@posva/vuefire-core'
 import { firestore } from 'firebase'
 import Vue, { PluginFunction } from 'vue'
+import { CombinedVueInstance } from 'vue/types/vue'
 
 const ops: OperationsType = {
   set: (target, key, value) => walkSet(target, key, value),
@@ -96,8 +97,15 @@ type VueFirestoreObject = Record<
 type FirestoreOption<V> = VueFirestoreObject | ((this: V) => VueFirestoreObject)
 
 declare module 'vue/types/options' {
-  interface ComponentOptions<V extends Vue> {
-    firestore?: FirestoreOption<V>
+  interface ComponentOptions<
+    V extends Vue,
+    Data = DefaultData<V>,
+    Methods = DefaultMethods<V>,
+    Computed = DefaultComputed,
+    PropsDef = PropsDefinition<DefaultProps>,
+    Props = DefaultProps
+  > {
+    firestore?: FirestoreOption<CombinedVueInstance<V, Data, Methods, Computed, Props>>
   }
 }
 
@@ -142,6 +150,7 @@ export const firestorePlugin: PluginFunction<PluginOptions> = function firestore
     },
     created(this: Vue) {
       const { firestore } = this.$options
+      // @ts-ignore
       const refs = typeof firestore === 'function' ? firestore.call(this) : firestore
       if (!refs) return
       for (const key in refs) {

--- a/packages/vuefire/src/index.ts
+++ b/packages/vuefire/src/index.ts
@@ -1,2 +1,32 @@
+import {
+  DefaultData,
+  DefaultMethods,
+  DefaultComputed,
+  ThisTypedComponentOptionsWithArrayProps,
+  DefaultProps,
+  ThisTypedComponentOptionsWithRecordProps,
+} from 'vue/types/options'
+
 export * from './rtdb'
 export * from './firestore'
+
+declare module 'vue/types/vue' {
+  interface VueConstructor<V extends Vue> {
+    extend<
+      Data = DefaultData<V>,
+      Methods = DefaultMethods<V>,
+      Computed = DefaultComputed,
+      PropNames extends string = never
+    >(
+      options?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames>
+    ): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>
+    extend<
+      Data = DefaultData<V>,
+      Methods = DefaultMethods<V>,
+      Computed = DefaultComputed,
+      Props = DefaultProps
+    >(
+      options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>
+    ): ExtendedVue<V, Data, Methods, Computed, Props>
+  }
+}

--- a/packages/vuefire/src/rtdb.ts
+++ b/packages/vuefire/src/rtdb.ts
@@ -8,6 +8,7 @@ import {
 } from '@posva/vuefire-core'
 import { database } from 'firebase'
 import Vue, { PluginFunction } from 'vue'
+import { CombinedVueInstance } from 'vue/types/vue'
 
 /**
  * Returns the original reference of a Firebase reference or query across SDK versions.
@@ -99,8 +100,15 @@ type VueFirebaseObject = Record<string, database.Query | database.Reference>
 type FirebaseOption<V> = VueFirebaseObject | ((this: V) => VueFirebaseObject)
 
 declare module 'vue/types/options' {
-  interface ComponentOptions<V extends Vue> {
-    firebase?: FirebaseOption<V>
+  interface ComponentOptions<
+    V extends Vue,
+    Data = DefaultData<V>,
+    Methods = DefaultMethods<V>,
+    Computed = DefaultComputed,
+    PropsDef = PropsDefinition<DefaultProps>,
+    Props = DefaultProps
+  > {
+    firebase?: FirebaseOption<CombinedVueInstance<V, Data, Methods, Computed, Props>>
   }
 }
 


### PR DESCRIPTION
## The problem
When using typescript, it is not possible to access properties defined in `this` context. It warns that the defined props are not available in the scope with the message `Error: "Property 'nameOfProp' doesn't exist on type Vue"`.

## Proposed solution
I augmented `VueConstructor` type so it passes default typings around on `extend` function (which doesn't happen in Vue itself) and passed a CombinedInstance type as `this` for the `firestore` and `firebase` functions.

I'm not sure if that's a good approach, cause it messes up with Vue module definition.
If you know a better way of implementing this, pls share.

## Still not fixed
- I haven't figured out yet how to infer methods, data and computed properties types. For now, it only infers prop types and treats everything else as `any`

fix #399 