### PR TITLE
docs: changes doc by snapshot in serialize example

### DIFF
--- a/packages/documentation/docs/api/vuefire.md
+++ b/packages/documentation/docs/api/vuefire.md
@@ -57,7 +57,7 @@ const serialize = (snapshot: firestore.DocumentSnapshot) => {
   // default, Vuefire adds it as a non enumerable property named id.
   // This allows to easily create copies when updating documents, as using
   // the spread operator won't copy it
-  return Object.defineProperty(doc.data(), 'id', { value: doc.id })
+  return Object.defineProperty(snapshot.data(), 'id', { value: snapshot.id })
 }
 
 Vue.use(firestorePlugin, { serialize })

--- a/packages/documentation/docs/api/vuefire.md
+++ b/packages/documentation/docs/api/vuefire.md
@@ -53,7 +53,7 @@ the Vue Instance. Here is the default function that is used when no override is 
 
 ```ts
 const serialize = (snapshot: firestore.DocumentSnapshot) => {
-  // documentSnapshot.data() DOES NOT contain the `id` of the document. By
+  // snapshot.data() DOES NOT contain the `id` of the document. By
   // default, Vuefire adds it as a non enumerable property named id.
   // This allows to easily create copies when updating documents, as using
   // the spread operator won't copy it


### PR DESCRIPTION
In this example :  
https://vuefire.vuejs.org/api/vuefire.html#options-serialize
```js
const serialize = (snapshot: firestore.DocumentSnapshot) => {
  // documentSnapshot.data() DOES NOT contain the `id` of the document. By
  // default, Vuefire adds it as a non enumerable property named id.
  // This allows to easily create copies when updating documents, as using
  // the spread operator won't copy it
  return Object.defineProperty(doc.data(), 'id', { value: doc.id })
}
```

`doc` isn't defined, i think it should be `snapshot` instead of.