### PR TITLE
fix(unbind): unbind correctly for Composition API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuefire",
-  "version": "3.0.0-alpha.2",
+  "version": "3.0.0-alpha.3",
   "description": "Some awesome description",
   "main": "dist/vuefire.cjs.js",
   "unpkg": "dist/vuefire.global-vue-2.js",

--- a/src/vuefire/firestore.ts
+++ b/src/vuefire/firestore.ts
@@ -266,13 +266,15 @@ export function bind(
     | firestore.DocumentReference,
   options?: FirestoreOptions
 ) {
-  const unbinds = {}
-  firestoreUnbinds.set(target, unbinds)
   const [promise, unbind] = internalBind(
     target,
     docOrCollectionRef as any,
     options
   )
+  const unbinds = {
+    '': unbind,
+  }
+  firestoreUnbinds.set(target, unbinds)
 
   // TODO: SSR serialize the values for Nuxt to expose them later and use them
   // as initial values while specifying a wait: true to only swap objects once


### PR DESCRIPTION
This experimental Vue3 branch mostly worked, but firestore unbind didn't work when using the Composition API format. There's probably a better way, but this works now.

--- 

Moving forward, it would be great if you could pass in a Reactive field not just a Ref 🙃
Vue helpfully exposes isRef and isReactive functions and I tried to update the lib accordingly but that’s a bit beyond my expertise for a PR.

--- 

BTW, re typescript:

I’m not sure re the best practices for extending the vue/runime-core module type but check out how vue-router does it by separating out the types. Their npm type declarations build script imports a globalExtensions file and appends it to the built extension.d.ts

https://github.com/vuejs/vue-router-next/blob/65816e13747de372a43ea8f7ac6bf121e44dd8e1/package.json#L20 

Or maybe there’s a more clever way of extending the type based on IF the developer calls app.use(plugin…) etc. I just ended up making these type extensions locally in my project. 
