### PR TITLE
fix: make @vue/composition-api optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
     "@vue/composition-api": "^1.0.0-beta.1",
     "vue": "^2.0.0 || >=3.0.0-rc.0"
   },
+  "peerDependenciesMeta": {
+    "@vue/composition-api": {
+      "optional": true
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/posva/vuefire.git"


### PR DESCRIPTION
NPM 7 attempts to automatically resolve peer dependencies and errors if it can't. This makes it difficult to use this package with Vue 3, since `@vue/composition-API` depends on Vue 2. This change brings `vuefire` in line with the README from `vue-demi`.

Pending this change, a workaround is to use `--legacy-peer-deps` when installing.