### PR TITLE
docs: Clarify potential gotcha when overriding serialize in rtdb

### DIFF
--- a/packages/documentation/docs/api/vuefire.md
+++ b/packages/documentation/docs/api/vuefire.md
@@ -226,6 +226,24 @@ const serialize = (snapshot: database.DataSnapshot) => {
 Vue.use(rtdbPlugin, { serialize })
 ```
 
+:::miniwarn
+Note that if the returned object doesn't have a `.key` property, this will break deletion from bound arrays as the deletion relies on it.
+:::
+
+To avoid issues, it is recommended to call the default function and add your own customization:
+
+```ts
+import { rtdbOptions } from 'vuexfire'
+
+const serialize = (snapshot: firebase.database.DataSnapshot) => {
+  // Call the default implementation to ensure we have a '.key' set
+  const val = rtdbOptions.serialize(snapshot)
+  // Add your own behavior here
+  val.myCustomId = snapshot.key
+  return val
+}
+```
+
 ## `firebase` option
 
 :::miniwarn


### PR DESCRIPTION
TLDR: The rtdb  `childRemoved` handler uses `indexForKey` to find the element to delete. This function assumes that a `.key` property is defined on objects, which won't be the case if you override the `serialize` option. This can lead to bugs when removing from array.

For example, I had the following, which doesn't define `.key`:

```
      await bindFirebaseRef('events', db.ref(FB_EVENT_PREFIX + aoiName + '/'), {
        serialize: (snapshot: firebase.database.DataSnapshot) => {
          const val = snapshot.val()
          val.date = new Date(val.date)
          return val
        }
      })
```

With this code, whenever I deleted an element from my array, it was always the last one that got removed. Took me a bit of time to figure out why deletion wasn't working, hence this documentation improvement.

The reason is that if `.key` is not defined, `indexForKey` [will return -1](https://github.com/vuejs/vuefire/blob/c781f6a98ef9216246ef4b8e8ff7cf5f4675e24c/packages/%40posva/vuefire-core/src/rtdb/utils.ts#L38) which ultimately will gets passed to [Array.slice](https://github.com/vuejs/vuefire/blob/c781f6a98ef9216246ef4b8e8ff7cf5f4675e24c/packages/vuefire/src/rtdb.ts#L27) which ends up removing the last item.

A better fix might be to throw an error instead of returning -1 in `indexForKey`. Happy to work on this if that's deemed better.