### PR TITLE
docs: fix example for "Updates to collection and documents"

### DIFF
--- a/packages/documentation/docs/vuexfire/writing-data.md
+++ b/packages/documentation/docs/vuexfire/writing-data.md
@@ -47,7 +47,7 @@ firestoreAction(({ state }) => {
   // return the promise so we can await this action
   return db
     .collection('users')
-    .doc(this.user.id)
+    .doc(state.user.id)
     .set(user)
     .then(() => {
       console.log('user updated!')


### PR DESCRIPTION
changing "this.user.id" to "state.user.id" in firestore example for "Updates to collection and documents"