### PR TITLE
refactor: split options api entry points

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -10,6 +10,14 @@ export default defineBuildConfig({
       input: './src/server/index',
       name: 'server/index',
     },
+    {
+      input: './src/options-api/firestore',
+      name: 'options-api/firestore',
+    },
+    {
+      input: './src/options-api/database',
+      name: 'options-api/database',
+    },
   ],
   declaration: true,
   externals: [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,16 @@
       "types": "./dist/server/index.d.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.cjs"
+    },
+    "./options-api/firestore": {
+      "types": "./dist/options-api/firestore.d.ts",
+      "import": "./dist/options-api/firestore.mjs",
+      "require": "./dist/options-api/firestore.cjs"
+    },
+    "./options-api/database": {
+      "types": "./dist/options-api/database.d.ts",
+      "import": "./dist/options-api/database.mjs",
+      "require": "./dist/options-api/database.cjs"
     }
   },
   "main": "./dist/index.cjs",

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -10,7 +10,6 @@ import {
 import { useFirebaseApp } from '../app'
 import { UseDatabaseRefOptions, _useDatabaseRef } from './useDatabaseRef'
 
-export { databasePlugin } from './optionsApi'
 export { globalDatabaseOptions } from './bind'
 export type { UseDatabaseRefOptions }
 

--- a/src/database/unbind.ts
+++ b/src/database/unbind.ts
@@ -1,6 +1,10 @@
 import type { Ref } from 'vue-demi'
 import type { UnbindWithReset, ResetOption } from '../shared'
-import { databaseUnbinds } from './optionsApi'
+
+export const databaseUnbinds = new WeakMap<
+  object,
+  Record<string, UnbindWithReset>
+>()
 
 export function internalUnbind(
   key: string,

--- a/src/firestore/unbind.ts
+++ b/src/firestore/unbind.ts
@@ -1,7 +1,11 @@
 import type { Ref } from 'vue-demi'
 import type { UnbindWithReset } from '../shared'
 import type { FirestoreRefOptions } from './bind'
-import { firestoreUnbinds } from './optionsApi'
+
+export const firestoreUnbinds = new WeakMap<
+  object,
+  Record<string, UnbindWithReset>
+>()
 
 export function internalUnbind(
   key: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,30 +43,72 @@ export type {
 /**
  * Database Options API
  */
+import {
+  databasePlugin as _databasePlugin,
+  databasePlugin as _rtdbPlugin,
+  VueFireDatabaseOptionsAPI as _VueFireDatabaseOptionsAPI,
+} from './options-api/database'
+import type {
+  DatabasePluginOptions as _DatabasePluginOptions,
+  VueFirebaseObject as _VueFirebaseObject,
+  FirebaseOption as _FirebaseOption,
+} from './options-api/database'
+
 export {
+  // already deprecated
   databasePlugin,
   // To ease migration
   databasePlugin as rtdbPlugin,
-  VueFireDatabaseOptionsAPI,
-} from './database/optionsApi'
-export type {
-  DatabasePluginOptions,
-  VueFirebaseObject,
-  FirebaseOption,
-} from './database/optionsApi'
+} from './options-api/database'
+
+// TODO: remove deprecations in v4
+/**
+ * @deprecated import from `vuefire/options-api/database` instead
+ */
+export const VueFireDatabaseOptionsAPI = _VueFireDatabaseOptionsAPI
+/**
+ * @deprecated import from `vuefire/options-api/database` instead
+ */
+export type DatabasePluginOptions = _DatabasePluginOptions
+/**
+ * @deprecated import from `vuefire/options-api/database` instead
+ */
+export type VueFirebaseObject = _VueFirebaseObject
+/**
+ * @deprecated import from `vuefire/options-api/database` instead
+ */
+export type FirebaseOption = _FirebaseOption
 
 /**
  * Firestore Options API
  */
-export {
-  firestorePlugin,
-  VueFireFirestoreOptionsAPI,
-} from './firestore/optionsApi'
-export type {
-  FirestorePluginOptions,
-  VueFirestoreObject,
-  FirestoreOption,
-} from './firestore/optionsApi'
+import { VueFireFirestoreOptionsAPI as _VueFireFirestoreOptionsAPI } from './options-api/firestore'
+import type {
+  FirestorePluginOptions as _FirestorePluginOptions,
+  VueFirestoreObject as _VueFirestoreObject,
+  FirestoreOption as _FirestoreOption,
+} from './options-api/firestore'
+
+// TODO: remove deprecations in v4
+/**
+ * @deprecated import from `vuefire/options-api/firestore` instead
+ */
+export const VueFireFirestoreOptionsAPI = _VueFireFirestoreOptionsAPI
+/**
+ * @deprecated import from `vuefire/options-api/firestore` instead
+ */
+export type FirestorePluginOptions = _FirestorePluginOptions
+/**
+ * @deprecated import from `vuefire/options-api/firestore` instead
+ */
+export type VueFirestoreObject = _VueFirestoreObject
+/**
+ * @deprecated import from `vuefire/options-api/firestore` instead
+ */
+export type FirestoreOption = _FirestoreOption
+
+// this one is deprecated already
+export { firestorePlugin } from './options-api/firestore'
 
 /**
  * App

--- a/src/options-api/database.ts
+++ b/src/options-api/database.ts
@@ -1,13 +1,13 @@
-import { FirebaseApp } from 'firebase/app'
-import { DatabaseReference, DataSnapshot, Query } from 'firebase/database'
+import type { FirebaseApp } from 'firebase/app'
+import type { DatabaseReference, DataSnapshot, Query } from 'firebase/database'
 import { App, ComponentPublicInstance, effectScope, toRef } from 'vue-demi'
 import { isVue3 } from 'vue-demi'
 import { useFirebaseApp } from '../app'
 import { getGlobalScope } from '../globals'
 import { ResetOption, UnbindWithReset } from '../shared'
-import { internalUnbind } from './unbind'
-import { _DatabaseRefOptions } from './bind'
-import { _useDatabaseRef } from './useDatabaseRef'
+import { databaseUnbinds, internalUnbind } from '../database/unbind'
+import { _DatabaseRefOptions } from '../database/bind'
+import { _useDatabaseRef } from '../database/useDatabaseRef'
 
 /**
  * Options for the Firebase Database Plugin that enables the Options API such as `$databaseBind` and `$databaseUnbind`.
@@ -33,11 +33,6 @@ const databasePluginDefaults: Readonly<
 
 export type VueFirebaseObject = Record<string, Query | DatabaseReference>
 export type FirebaseOption = VueFirebaseObject | (() => VueFirebaseObject)
-
-export const databaseUnbinds = new WeakMap<
-  object,
-  Record<string, UnbindWithReset>
->()
 
 /**
  * Install this plugin if you want to add `$databaseBind` and `$databaseUnbind` functions. Note this plugin is only necessary if

--- a/src/options-api/firestore.ts
+++ b/src/options-api/firestore.ts
@@ -11,23 +11,18 @@ import {
   toRef,
   isVue3,
 } from 'vue-demi'
-import { FirestoreRefOptions } from './bind'
-import { _useFirestoreRef } from './useFirestoreRef'
+import { FirestoreRefOptions } from '../firestore/bind'
+import { _useFirestoreRef } from '../firestore/useFirestoreRef'
 import { ResetOption, UnbindWithReset, _FirestoreDataSource } from '../shared'
-import { FirebaseApp } from 'firebase/app'
+import type { FirebaseApp } from 'firebase/app'
 import { getGlobalScope } from '../globals'
 import { useFirebaseApp } from '../app'
-import { internalUnbind } from './unbind'
+import { firestoreUnbinds, internalUnbind } from '../firestore/unbind'
 
 // TODO: this should be an entry point to generate the corresponding .d.ts file that only gets included if the plugin is imported
 
 export type VueFirestoreObject = Record<string, _FirestoreDataSource>
 export type FirestoreOption = VueFirestoreObject | (() => VueFirestoreObject)
-
-export const firestoreUnbinds = new WeakMap<
-  object,
-  Record<string, UnbindWithReset>
->()
 
 /**
  * Options for the Firebase Database Plugin that enables the Options API such as `$firestoreBind` and
@@ -55,7 +50,7 @@ const firestorePluginDefaults: Readonly<
 /**
  * Install this plugin to add `$firestoreBind` and `$firestoreUnbind` functions. Note this plugin is not necessary if
  * you exclusively use the Composition API (`useDocument()` and `useCollection()`).
- * @deprecated Use `VueFire` and `VueFireFirestoreOptionsAPI` with the `modules` option instead.b
+ * @deprecated Use `VueFire` and `VueFireFirestoreOptionsAPI` with the `modules` option instead.
  *
  * @param app
  * @param pluginOptions
@@ -168,7 +163,8 @@ export const firestorePlugin = function firestorePlugin(
  *
  * ```ts
  * import { createApp } from 'vue'
- * import { VueFire, VueFireFirestoreOptionsAPI } from 'vuefire'
+ * import { VueFire } from 'vuefire'
+ * import { VueFireFirestoreOptionsAPI } from 'vuefire/options-api/firestore'
  *
  * const app = createApp(App)
  * app.use(VueFire, {


### PR DESCRIPTION
This should include the types only if the plugins are imported from the correct entries once the deprecated versions are removed. It requires some extra testing before merging