### PR TITLE
fix: consider the serviceAccount config variable during setup

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -109,8 +109,12 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
         options.admin.serviceAccount
     }
     const hasServiceAccount =
-      typeof process.env.GOOGLE_APPLICATION_CREDENTIALS === 'string' &&
-      process.env.GOOGLE_APPLICATION_CREDENTIALS.length > 0
+      (typeof process.env.GOOGLE_APPLICATION_CREDENTIALS === 'string' &&
+      process.env.GOOGLE_APPLICATION_CREDENTIALS.length > 0) || (
+        options.admin &&
+        options.admin.serviceAccount != null &&
+        typeof options.admin.serviceAccount === 'object'
+      )
 
     // NOTE: the order of the plugins is reversed, so we end by adding the app plugin which is used by all other
     // plugins


### PR DESCRIPTION
according to the configuration, the `serviceAccount` can be an instance of `ServiceAccount`, but in the setup script, while mounting the session handler for minting cookies, the config variable is not considered, leading to the routes not being injected, and `getCurrentUser` composable returning `undefined`.

This PR sends a fix in the setup, which also considers the `serviceAccount` config option while injecting serverHandler and plugin

Before (serverHandler not being registered):
![image](https://user-images.githubusercontent.com/18086566/214780936-b0877547-08d7-45f3-b7de-a0f035fd6a63.png)

Now (the serverHandler getting registered):
![image](https://user-images.githubusercontent.com/18086566/214781070-230e22f8-c89b-4014-bfa7-b5d772e1c1f2.png)
