### PR TITLE
docs: deprecations correction in migration

### DIFF
--- a/docs/cookbook/migration-v2-v3.md
+++ b/docs/cookbook/migration-v2-v3.md
@@ -26,7 +26,7 @@ The `firestorePlugin` and `rtdbPlugin` are now deprecated in favor of _modules_.
 
  // for database
 -app.use(rtdbPlugin)
-+app.use(VueFire, { modules: [VueFireFirestoreOptionsAPI] })
++app.use(VueFire, { modules: [VueFireDatabaseOptionsAPI] })
 ````
 
 ## Breaking changes


### PR DESCRIPTION
Fix a wrong module call on the document, it was being called VueFireFirestoreOptionsAPI (instead of VueFireDatabaseOptionsAPI) in the database apart.