### PR TITLE
feat: allow using service account with environment variables

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -8,7 +8,6 @@ import {
   createResolver,
   defineNuxtModule,
 } from '@nuxt/kit'
-import type { NuxtModule } from '@nuxt/schema'
 // cannot import from firebase/app because the build fails, maybe a nuxt bug?
 import type { FirebaseApp, FirebaseOptions } from '@firebase/app-types'
 import type {
@@ -20,6 +19,7 @@ import { markRaw } from 'vue'
 import type { NuxtVueFireAppCheckOptions } from './runtime/app-check'
 import { addMissingAlias } from './firebaseAliases'
 import { log } from './runtime/logging'
+import { isServiceAccountConfigured } from './runtime/config'
 
 export interface VueFireNuxtModuleOptions {
   /**
@@ -108,9 +108,7 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
       process.env.GOOGLE_APPLICATION_CREDENTIALS ||=
         options.admin.serviceAccount
     }
-    const hasServiceAccount =
-      typeof process.env.GOOGLE_APPLICATION_CREDENTIALS === 'string' &&
-      process.env.GOOGLE_APPLICATION_CREDENTIALS.length > 0
+    const hasServiceAccount = isServiceAccountConfigured(options)
 
     // NOTE: the order of the plugins is reversed, so we end by adding the app plugin which is used by all other
     // plugins

--- a/packages/nuxt/src/runtime/config.ts
+++ b/packages/nuxt/src/runtime/config.ts
@@ -1,0 +1,23 @@
+import { VueFireNuxtModuleOptions } from '../module'
+
+export function isServiceAccountConfigured(options: VueFireNuxtModuleOptions) {
+  const hasServiceAccountFile =
+    typeof process.env.GOOGLE_APPLICATION_CREDENTIALS === 'string' &&
+    process.env.GOOGLE_APPLICATION_CREDENTIALS.length > 0
+
+  if (hasServiceAccountFile) {
+    return true
+  }
+
+  if (typeof options.admin?.serviceAccount === 'object') {
+    if (
+      options.admin.serviceAccount.clientEmail?.length &&
+      options.admin.serviceAccount.privateKey?.length &&
+      options.admin.serviceAccount.projectId?.length
+    ) {
+      return true
+    }
+  }
+
+  return false
+}


### PR DESCRIPTION
Attempt to resolve issue #1297:

When using environment variables to use the service account, the service account is considered as not configured if it's something else than the service account's file's path. This PR keeps the initial check of the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to determine if the service account file's path is provided, then checks if all the required fields of the service account's options are provided to consider as configured.