### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/packages/nuxt/src/runtime/admin/plugin.server.ts
+++ b/packages/nuxt/src/runtime/admin/plugin.server.ts
@@ -1,6 +1,6 @@
 import { type App as AdminApp } from 'firebase-admin/app'
 import { ensureAdminApp } from 'vuefire/server'
-import { defineNuxtPlugin, useRequestEvent, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRequestEvent, useRuntimeConfig } from '#imports'
 
 export default defineNuxtPlugin(() => {
   const event = useRequestEvent()

--- a/packages/nuxt/src/runtime/analytics/plugin.client.ts
+++ b/packages/nuxt/src/runtime/analytics/plugin.client.ts
@@ -1,6 +1,6 @@
 import type { FirebaseApp } from 'firebase/app'
 import { isSupported, initializeAnalytics } from 'firebase/analytics'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
  * Plugin to initialize the analytics module.

--- a/packages/nuxt/src/runtime/app-check/plugin.client.ts
+++ b/packages/nuxt/src/runtime/app-check/plugin.client.ts
@@ -6,7 +6,7 @@ import {
   type AppCheckOptions,
 } from 'firebase/app-check'
 import { VueFireAppCheck } from 'vuefire'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
  * Plugin to initialize the appCheck module on the server.

--- a/packages/nuxt/src/runtime/app-check/plugin.server.ts
+++ b/packages/nuxt/src/runtime/app-check/plugin.server.ts
@@ -1,7 +1,7 @@
 import type { App as FirebaseAdminApp } from 'firebase-admin/app'
 import type { FirebaseApp } from 'firebase/app'
 import { VueFireAppCheckServer } from 'vuefire/server'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 /**
  * Makes AppCheck work on the server. This requires SSR and the admin SDK to be available

--- a/packages/nuxt/src/runtime/app/composables.ts
+++ b/packages/nuxt/src/runtime/app/composables.ts
@@ -1,5 +1,5 @@
 import type { FirebaseApp } from 'firebase/app'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 
 /**
  * Gets the firebase instance from the current Nuxt App. This can be used anywhere the `useNuxtApp()` can be used. Differently from `vuefire`'s `useFirebaseApp()`, this doesn't accept a name.

--- a/packages/nuxt/src/runtime/app/plugin.client.ts
+++ b/packages/nuxt/src/runtime/app/plugin.client.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
  * Initializes the app and provides it to others.

--- a/packages/nuxt/src/runtime/app/plugin.server.ts
+++ b/packages/nuxt/src/runtime/app/plugin.server.ts
@@ -4,7 +4,7 @@ import { type DecodedIdToken } from 'firebase-admin/auth'
 import { logger } from '../logging'
 import { DECODED_ID_TOKEN_SYMBOL } from '../constants'
 import { appCache } from './lru-cache'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
  * Initializes the app and provides it to others.

--- a/packages/nuxt/src/runtime/auth/plugin-mint-cookie.client.ts
+++ b/packages/nuxt/src/runtime/auth/plugin-mint-cookie.client.ts
@@ -5,7 +5,7 @@ import {
   beforeAuthStateChanged,
   type User,
 } from 'firebase/auth'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 /**
  * Sets up a watcher that mints a cookie based auth session. On the server, it reads the cookie to

--- a/packages/nuxt/src/runtime/auth/plugin-user-token.server.ts
+++ b/packages/nuxt/src/runtime/auth/plugin-user-token.server.ts
@@ -2,7 +2,7 @@ import type { App as AdminApp } from 'firebase-admin/app'
 import { decodeSessionCookie, AUTH_COOKIE_NAME } from 'vuefire/server'
 import { getCookie } from 'h3'
 import { DECODED_ID_TOKEN_SYMBOL } from '../constants'
-import { defineNuxtPlugin, useRequestEvent } from '#app'
+import { defineNuxtPlugin, useRequestEvent } from '#imports'
 
 /**
  * Decodes the user token if any. Should only be added on the server and before the firebase/app

--- a/packages/nuxt/src/runtime/auth/plugin.client.ts
+++ b/packages/nuxt/src/runtime/auth/plugin.client.ts
@@ -1,7 +1,7 @@
 import type { FirebaseApp } from 'firebase/app'
 import type { User } from 'firebase/auth'
 import { VueFireAuth } from 'vuefire'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 /**
  * Setups VueFireAuth for the client. This version creates some listeners that shouldn't be set on server.

--- a/packages/nuxt/src/runtime/auth/plugin.server.ts
+++ b/packages/nuxt/src/runtime/auth/plugin.server.ts
@@ -8,7 +8,7 @@ import type { App as AdminApp } from 'firebase-admin/app'
 import { VueFireAuthServer } from 'vuefire/server'
 import { DECODED_ID_TOKEN_SYMBOL, UserSymbol } from '../constants'
 import { logger } from '../logging'
-import { defineNuxtPlugin, useRequestEvent } from '#app'
+import { defineNuxtPlugin, useRequestEvent } from '#imports'
 
 /**
  * Setups the auth state based on the cookie.

--- a/packages/nuxt/src/runtime/emulators/auth.plugin.ts
+++ b/packages/nuxt/src/runtime/emulators/auth.plugin.ts
@@ -1,7 +1,7 @@
 import { connectAuthEmulator, getAuth } from 'firebase/auth'
 import type { FirebaseApp } from 'firebase/app'
 import { logger } from '../logging'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
  * Setups the auth Emulators

--- a/packages/nuxt/src/runtime/emulators/database.plugin.ts
+++ b/packages/nuxt/src/runtime/emulators/database.plugin.ts
@@ -1,7 +1,7 @@
 import { getDatabase, connectDatabaseEmulator } from 'firebase/database'
 import type { FirebaseApp } from 'firebase/app'
 import { logger } from '../logging'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
  * Setups the Database Emulators

--- a/packages/nuxt/src/runtime/emulators/firestore.plugin.ts
+++ b/packages/nuxt/src/runtime/emulators/firestore.plugin.ts
@@ -1,7 +1,7 @@
 import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore'
 import type { FirebaseApp } from 'firebase/app'
 import { logger } from '../logging'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
  * Setups the Firestore Emulators

--- a/packages/nuxt/src/runtime/emulators/functions.plugin.ts
+++ b/packages/nuxt/src/runtime/emulators/functions.plugin.ts
@@ -1,7 +1,7 @@
 import { getFunctions, connectFunctionsEmulator } from 'firebase/functions'
 import type { FirebaseApp } from 'firebase/app'
 import { logger } from '../logging'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
  * Setups the Functions Emulators

--- a/packages/nuxt/src/runtime/emulators/storage.plugin.ts
+++ b/packages/nuxt/src/runtime/emulators/storage.plugin.ts
@@ -1,7 +1,7 @@
 import { getStorage, connectStorageEmulator } from 'firebase/storage'
 import type { FirebaseApp } from 'firebase/app'
 import { logger } from '../logging'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
  * Setups the Storage Emulators

--- a/packages/nuxt/src/runtime/payload-plugin.ts
+++ b/packages/nuxt/src/runtime/payload-plugin.ts
@@ -4,7 +4,7 @@ import {
   definePayloadPlugin,
   definePayloadReducer,
   definePayloadReviver,
-} from '#app'
+} from '#imports'
 
 /**
  * Handles Firestore Timestamps, GeoPoint, and other types that needs special handling for serialization.

--- a/packages/nuxt/templates/plugin.ejs
+++ b/packages/nuxt/templates/plugin.ejs
@@ -2,7 +2,7 @@ import {
   VueFire,
   useSSRInitialState,
 } from 'vuefire'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin((nuxtApp) => {
   const firebaseApp = nuxtApp.$firebaseApp


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.