### PR TITLE
fix(nuxt): give plugins `.mjs` extension so they're processed

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -170,6 +170,7 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
     // this adds the VueFire plugin and handle SSR state serialization and hydration
     addPluginTemplate({
       src: normalize(resolve(templatesDir, 'plugin.ejs')),
+      filename: 'vuefire-plugin.mjs',
       options: {
         ssr: nuxt.options.ssr,
       },
@@ -232,6 +233,7 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
       // hydrates the user if any
       addPluginTemplate({
         src: normalize(resolve(runtimeDir, 'auth/plugin.client.ejs')),
+        filename: 'vuefire-auth-plugin.mjs',
         options: {
           ...options.auth,
         },


### PR DESCRIPTION
https://github.com/nuxt/nuxt/issues/24733 is caused by Nuxt not treating `.ejs` files as JavaScript (and therefore not running certain build plugins on the code within them).

We might be able to handle this transparently within Nuxt as well but this PR fixes it in a backwards-compatible way.