### PR TITLE
fix: bindFirestoreRef not reacting to getter

### DIFF
--- a/src/database/useDatabaseRef.ts
+++ b/src/database/useDatabaseRef.ts
@@ -134,7 +134,7 @@ export function _useDatabaseRef(
   }
 
   let stopWatcher = noop
-  if (isRef(reference)) {
+  if (isRef(reference) || typeof reference === 'function') {
     stopWatcher = watch(reference, bindDatabaseRef)
   }
   bindDatabaseRef()

--- a/src/firestore/useFirestoreRef.ts
+++ b/src/firestore/useFirestoreRef.ts
@@ -164,7 +164,9 @@ export function _useFirestoreRef(
   }
 
   let stopWatcher = noop
-  stopWatcher = watch(() => toValue(docOrCollectionRef), bindFirestoreRef)
+  if (isRef(docOrCollectionRef) || typeof docOrCollectionRef === 'function') {
+    stopWatcher = watch(docOrCollectionRef, bindFirestoreRef)
+  }
 
   bindFirestoreRef()
 

--- a/src/firestore/useFirestoreRef.ts
+++ b/src/firestore/useFirestoreRef.ts
@@ -164,9 +164,7 @@ export function _useFirestoreRef(
   }
 
   let stopWatcher = noop
-  if (isRef(docOrCollectionRef)) {
-    stopWatcher = watch(docOrCollectionRef, bindFirestoreRef)
-  }
+  stopWatcher = watch(() => toValue(docOrCollectionRef), bindFirestoreRef)
 
   bindFirestoreRef()
 

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -75,7 +75,7 @@ export function useStorageFileUrl(
   }
 
   refresh()
-  if (isRef(storageRef)) {
+  if (isRef(storageRef) || typeof storageRef === 'function') {
     watch(storageRef, refresh)
   }
 
@@ -255,7 +255,7 @@ export function useStorageFile(
     return Promise.all([refreshUrl(), refreshMetadata()])
   }
 
-  if (isRef(storageRef)) {
+  if (isRef(storageRef) || typeof storageRef === 'function') {
     watch(storageRef, (storageSource) => {
       if (!storageSource) {
         if (uploadTask.value) {

--- a/tests/database/list.spec.ts
+++ b/tests/database/list.spec.ts
@@ -287,6 +287,33 @@ describe('Database lists', () => {
     expect(data.value).toContainEqual({ text: 'task 3' })
   })
 
+  it('can be bound to a getter', async () => {
+    const listA = databaseRef()
+    const listB = databaseRef()
+    await push(listA, { text: 'task 1' })
+    await push(listA, { text: 'task 2' })
+    await push(listB, { text: 'task 3' })
+    await push(listA, { text: 'task 4' })
+    const showFinished = ref(true)
+
+    const { wrapper, data, promise } = factory({
+      ref: () => (showFinished.value ? listA : listB),
+    })
+
+    await promise.value
+    expect(data.value).toHaveLength(3)
+    expect(data.value).toContainEqual({ text: 'task 1' })
+    expect(data.value).toContainEqual({ text: 'task 2' })
+    expect(data.value).toContainEqual({ text: 'task 4' })
+
+    showFinished.value = false
+    await nextTick()
+    await promise.value
+    await nextTick()
+    expect(data.value).toHaveLength(1)
+    expect(data.value).toContainEqual({ text: 'task 3' })
+  })
+
   it('reorders items in the array', async () => {
     const listRef = databaseRef()
     const orderedListRef = query(listRef, orderByChild('n'))

--- a/tests/firestore/collection.spec.ts
+++ b/tests/firestore/collection.spec.ts
@@ -74,7 +74,7 @@ describe(
 
     function factoryQuery<
       AppModelType = DocumentData,
-      DbModelType extends DocumentData = DocumentData
+      DbModelType extends DocumentData = DocumentData,
     >({
       options,
       ref,
@@ -358,8 +358,8 @@ describe(
         showFinished.value
           ? finishedListRef
           : showFinished.value === false
-          ? unfinishedListRef
-          : null
+            ? unfinishedListRef
+            : null
       )
       await addDoc(listRef, { text: 'task 1', finished: false })
       await addDoc(listRef, { text: 'task 2', finished: false })
@@ -396,6 +396,31 @@ describe(
       await nextTick()
       expect(data.value).toHaveLength(1)
       expect(data.value).toContainEqual({ text: 'task 3', finished: true })
+    })
+
+    it('can be bound to a getter', async () => {
+      const listCollectionRef = collection<{ name: string }>(
+        'populatedCollection'
+      )
+      const collectionName = ref('populatedCollection')
+
+      const { wrapper, promise } = factory({
+        ref: () => collection(collectionName.value),
+      })
+
+      await promise.value
+      await addDoc(listCollectionRef, { name: 'a' })
+      await addDoc(listCollectionRef, { name: 'b' })
+
+      expect(wrapper.vm.list).toHaveLength(2)
+      expect(wrapper.vm.list).toContainEqual({ name: 'a' })
+      expect(wrapper.vm.list).toContainEqual({ name: 'b' })
+
+      collectionName.value = 'emptyCollection'
+      await nextTick()
+      await promise.value
+      await nextTick()
+      expect(wrapper.vm.list).toHaveLength(0)
     })
 
     it('can be bound to a null ref', async () => {


### PR DESCRIPTION
Closes #1495

Checking if the `docOrCollectionRef` is a ref before setting up a watch to re-bind the firestore meant getters weren't being watched. 

Using `watch(() => toValue(docOrCollectionRef), bindFirestoreRef)` will keep the old behaviour of tracking refs and computeds while also tracking getters.

In this case, we also don't need to check what `docOrCollectionRef` is.
Unless there is a cost in watching an non-reactive source (I don't think so, but I'm not sure).

I'm still learning my way around the tests, I tried the following, but the tests hangs and fails:

```ts
it('can be bound to a getter', async () => {
  const listCollectionRef = collection<{ name: string }>()
  const listRef = ref<null | CollectionReference>(null)

  const { wrapper } = factory({
    ref: () => listRef.value,
  })

  await addDoc(listCollectionRef, { name: 'a' })
  await addDoc(listCollectionRef, { name: 'b' })

  expect(wrapper.vm.list).toHaveLength(0)
  listRef.value = listCollectionRef
  expect(wrapper.vm.list).toContainEqual({ name: 'a' })
  expect(wrapper.vm.list).toContainEqual({ name: 'b' })
})
```

But I must be doing something wrong because even when I use `ref: listRef` it also fails, but `ref: listCollectionRef` it works.
I'll keep the PR as a draft while I work on those tests.

