### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/packages/nuxt/playground/pages/firestore-useDocument.vue
+++ b/packages/nuxt/playground/pages/firestore-useDocument.vue
@@ -57,14 +57,14 @@ const { data: config, promise } = useDocument(configRef, { wait: true })
 
 onMounted(() => {
   promise.value.then((data) => {
-    if (process.client) {
+    if (import.meta.client) {
       console.log('promise resolved', toRaw(data))
     }
     isDoneFetching.value = true
   })
 
   usePendingPromises().then((data) => {
-    if (process.client) {
+    if (import.meta.client) {
       console.log('pending promise resolved', toRaw(data))
     }
     isAllDoneFetching.value = true

--- a/packages/nuxt/src/runtime/analytics/composables.ts
+++ b/packages/nuxt/src/runtime/analytics/composables.ts
@@ -8,5 +8,5 @@ import { useFirebaseApp } from '../app/composables'
  * @returns the Analytics instance
  */
 export function useAnalytics() {
-  return process.client ? getAnalytics(useFirebaseApp()) : null
+  return import.meta.client ? getAnalytics(useFirebaseApp()) : null
 }

--- a/packages/nuxt/templates/plugin.ejs
+++ b/packages/nuxt/templates/plugin.ejs
@@ -10,7 +10,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(VueFire, { firebaseApp })
 
   <% if(options.ssr) { %>
-  if (process.server) {
+  if (import.meta.server) {
     // collect the initial state
     nuxtApp.payload.vuefire = useSSRInitialState(undefined, firebaseApp)
   } else if (nuxtApp.payload?.vuefire) {


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)