### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can follow the progress and future plans on [the Roadmap issue](https://gith
 VueFire requires the `firebase` package to be installed as well as `vuefire`:
 
 ```bash
-npm install vuefire firebase
+npx nuxi@latest module add vuefire
 ```
 
 Check [the documentation](https://vuefire.vuejs.org/nuxt/getting-started.html) for Nuxt instructions.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -5,22 +5,9 @@ Before using VueFire, make sure you have a Firebase account and a project setup 
 ## Installation
 
 In order to get started make sure to install the latest version of `vuefire` as well as `firebase`:
-
-::: code-group
-
-```sh [pnpm]
-pnpm i vuefire firebase
+```bash
+npx nuxi@latest module add vuefire
 ```
-
-```sh [yarn]
-yarn add vuefire firebase
-```
-
-```sh [npm]
-npm i vuefire firebase
-```
-
-:::
 
 ::: warning
 

--- a/docs/nuxt/getting-started.md
+++ b/docs/nuxt/getting-started.md
@@ -3,22 +3,9 @@
 VueFire comes with an official Nuxt module that automatically handles most of the hassle of setting up VueFire in your Nuxt project.
 
 ## Installation
-
-::: code-group
-
-```sh [pnpm]
-pnpm install vuefire nuxt-vuefire firebase
+```bash
+npx nuxi@latest module add vuefire
 ```
-
-```sh [yarn]
-yarn add vuefire nuxt-vuefire firebase
-```
-
-```sh [npm]
-npm install vuefire nuxt-vuefire firebase
-```
-
-:::
 
 Additionally, if you are using [SSR](https://nuxt.com/docs/api/configuration/nuxt-config/#ssr), you need to install `firebase-admin` and its peer dependencies:
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
