### PR TITLE
fix(nuxt): use `lodash.template` directly to compile templates

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -67,6 +67,7 @@
     "@nuxt/module-builder": "^0.8.1",
     "@nuxt/schema": "^3.10.3",
     "@nuxt/test-utils": "^3.11.0",
+    "@types/lodash-es": "^4.17.12",
     "eslint": "^8.56.0",
     "firebase": "^10.8.0",
     "firebase-admin": "^12.0.0",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@nuxt/kit": "^3.10.3",
     "@posva/lru-cache": "^10.0.1",
+    "lodash-es": "^4.17.21",
     "strip-json-comments": "^5.0.1"
   },
   "peerDependencies": {

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { template } from 'lodash-es'
 /**
  * @module nuxt-vuefire
  */
@@ -169,7 +171,13 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
 
     // this adds the VueFire plugin and handle SSR state serialization and hydration
     addPluginTemplate({
-      src: normalize(resolve(templatesDir, 'plugin.ejs')),
+      getContents({ options }) {
+        const contents = readFileSync(
+          normalize(resolve(templatesDir, 'plugin.ejs')),
+          'utf-8'
+        )
+        return template(contents)({ options })
+      },
       filename: 'vuefire-plugin.mjs',
       options: {
         ssr: nuxt.options.ssr,
@@ -232,7 +240,13 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
     if (options.auth.enabled) {
       // hydrates the user if any
       addPluginTemplate({
-        src: normalize(resolve(runtimeDir, 'auth/plugin.client.ejs')),
+        getContents({ options }) {
+          const contents = readFileSync(
+            normalize(resolve(runtimeDir, 'auth/plugin.client.ejs')),
+            'utf-8'
+          )
+          return template(contents)({ options })
+        },
         filename: 'vuefire-auth-plugin.client.mjs',
         options: {
           ...options.auth,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       '@nuxt/test-utils':
         specifier: ^3.11.0
         version: 3.13.1(@vitest/ui@2.0.2(vitest@2.0.2))(@vue/test-utils@2.4.6)(h3@1.12.0)(happy-dom@14.12.3)(magicast@0.3.4)(nitropack@2.9.7(encoding@0.1.13)(magicast@0.3.4))(rollup@4.18.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))(vitest@2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(happy-dom@14.12.3)(terser@5.31.2))(vue-router@4.4.0(vue@3.4.31(typescript@5.5.3)))(vue@3.4.31(typescript@5.5.3))
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1992,6 +1995,12 @@ packages:
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+
+  '@types/lodash@4.17.6':
+    resolution: {integrity: sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==}
 
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
@@ -8222,6 +8231,12 @@ snapshots:
       '@types/node': 20.14.10
 
   '@types/linkify-it@5.0.0': {}
+
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.6
+
+  '@types/lodash@4.17.6': {}
 
   '@types/long@4.0.2':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@posva/lru-cache':
         specifier: ^10.0.1
         version: 10.0.1
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       strip-json-comments:
         specifier: ^5.0.1
         version: 5.0.1
@@ -4207,6 +4210,9 @@ packages:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -5085,7 +5091,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.11.0:
@@ -11038,6 +11043,8 @@ snapshots:
   locate-path@7.2.0:
     dependencies:
       p-locate: 6.0.0
+
+  lodash-es@4.17.21: {}
 
   lodash.camelcase@4.3.0: {}
 


### PR DESCRIPTION
We are going to be removing support for [compiling templates from disk using `lodash.template`](https://github.com/nuxt/nuxt/issues/25332) in Nuxt v4. This is a PR to move lodash usage directly into vuefire's Nuxt module.

It would also be possible to avoid using it entirely, which I would _strongly_ recommend, either:
* using a custom function to handle the replacement, such as in https://github.com/nuxt-modules/color-mode/pull/240
* or moving the string interpolation logic directly into `getContents`

