### PR TITLE
Update options-api-realtime-data.md

### DIFF
--- a/docs/guide/options-api-realtime-data.md
+++ b/docs/guide/options-api-realtime-data.md
@@ -235,12 +235,12 @@ this.$databaseUnbind('user', () => ({ name: 'unregistered' }))
 ```
 
 ```js
-// default behavior
+// default behavior is to keep current value
 this.$firestoreUnbind('user')
 this.$firestoreUnbind('user', false)
 // this.user === { name: 'Eduardo' }
 
-// using a boolean value for reset to keep current value
+// if you send Boolean true in the reset parameter, the value will change to null
 this.$firestoreUnbind('user', true)
 // this.user === null
 


### PR DESCRIPTION
Currently the explanation for the reset is backwards, saying that you should send `true` if you want to `keep current value`. In fact, you should send `false` to keep the current value, and `true` to replace it with null.