### PR TITLE
docs: add Nuxt note about public environment variables

### DIFF
--- a/docs/nuxt/environment-variables.md
+++ b/docs/nuxt/environment-variables.md
@@ -2,6 +2,8 @@
 
 Nuxt VueFire automatically picks up a few environment variables to configure Firebase from your `.env` file. These usually take precedence over other options defined in `nuxt.config.ts`. They usually try to support the existing Firebase environment variables better.
 
+The VueFire config is treated as public Nuxt config, which means that any env variable [defined using the Nuxt convention](https://nuxt.com/docs/guide/going-further/runtime-config#environment-variables) will automatically be picked up by Nuxt. This means you can add, for example, `NUXT_PUBLIC_VUEFIRE_CONFIG_API_KEY=xyz` to your `.env` file and the value will populate in your app at runtime. You will still need to provide empty string values to the vuefire config to prevent an error during development.
+
 ## Admin SDK
 
 During development, if you are doing SSR, you must provide the `GOOGLE_APPLICATION_CREDENTIALS` environment variable with the path to the service account file. This is usually a JSON file you can download from the Firebase Console > Project Settings > Service Accounts > Generate new private key.

--- a/docs/nuxt/environment-variables.md
+++ b/docs/nuxt/environment-variables.md
@@ -2,7 +2,8 @@
 
 Nuxt VueFire automatically picks up a few environment variables to configure Firebase from your `.env` file. These usually take precedence over other options defined in `nuxt.config.ts`. They usually try to support the existing Firebase environment variables better.
 
-The VueFire config is treated as public Nuxt config, which means that any env variable [defined using the Nuxt convention](https://nuxt.com/docs/guide/going-further/runtime-config#environment-variables) will automatically be picked up by Nuxt. This means you can add, for example, `NUXT_PUBLIC_VUEFIRE_CONFIG_API_KEY=xyz` to your `.env` file and the value will populate in your app at runtime. You will still need to provide empty string values to the vuefire config to prevent an error during development.
+Since VueFire config is treated as _Public Runtime Config_, it can also be overridden with [env variables by following the Nuxt convention](https://nuxt.com/docs/guide/going-further/runtime-config#environment-variables). For example, an environment variable named `NUXT_PUBLIC_VUEFIRE_CONFIG_API_KEY=xyz` will override the `config.apiKey`.
+Note you still need to provide empty string values to each `config` property that is defined this way.
 
 ## Admin SDK
 


### PR DESCRIPTION
I know it's longer than 1 sentence, but I think an example would be beneficial.

On a related note, I wonder if having the lack of vuefire config a warning instead of an error would be a better dx. This is how the Sanity module does it (and doesn't prevent Nuxt from starting altogether):

![image](https://github.com/user-attachments/assets/30003e3a-3c57-4747-a555-4831f3adf36d)

vs Vuefire:

![image](https://github.com/user-attachments/assets/bfa0eb4a-3462-4db6-81d6-f9f016cfa57a)
