### PR TITLE
Option to do Client only auth with SSR

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -208,7 +208,9 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
       }
 
       // loads the user on the current app
-      addPlugin(resolve(runtimeDir, 'auth/plugin-authenticate-user.server'))
+      if(!options.auth.clientOnly){
+        addPlugin(resolve(runtimeDir, 'auth/plugin-authenticate-user.server'))
+      }
     }
 
     // Emulators must be enabled after the app is initialized but before some APIs like auth.signinWithCustomToken() are called


### PR DESCRIPTION
In my usage I found it lacked the need to support client only Auth with SSR. Currently I only want to do authentication on the client, but still want to fetch firestore data that doesn't require an authenticated user to be able to retrieve this data on the server.

This change should be compatible with all the old versions without any breaking changes.
To only allow authentication on the client during SSR:

```javascript
    auth: {
      enabled: true,
      clientOnly: true
    }
```

Before this would require an admin service-account to be included in your project so that the app could fetch the server data, with this check we disable the loading of the `plugin-authenticate-user.server`, and can start a firebase app on the server without firebaseAuth and retrieve public/accessible data of firestore without needing an authorisation.
