### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -449,7 +449,7 @@ declare module '#app' {
     $firebaseAdminApp: FirebaseAdminApp
   }
 }
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     /**
      * Firebase App instance.

--- a/src/database/optionsApi.ts
+++ b/src/database/optionsApi.ts
@@ -186,7 +186,7 @@ export function VueFireDatabaseOptionsAPI(
 
 type Mutable<T> = { -readonly [P in keyof T]: T[P] }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     /**
      * Binds a reference

--- a/src/firestore/optionsApi.ts
+++ b/src/firestore/optionsApi.ts
@@ -184,7 +184,7 @@ export function VueFireFirestoreOptionsAPI(
   }
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     /**
      * Binds a reference


### PR DESCRIPTION

In line with https://github.com/vuejs/router/pull/2295 and https://github.com/nuxt/nuxt/pull/28542, this moves to augment `vue` rather than `@vue/runtime` core.

This is now officially recommended [in the docs](https://vuejs.org/api/utility-types.html#componentcustomproperties) and it _must_ be done by all libraries or it will break types for _other_ libraries.