### PR TITLE
chore: Add support for Firebase JS SDK v11 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "consola": "^3.2.3",
-    "firebase": "^9.0.0 || ^10.0.0",
+    "firebase": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "vue": "^2.7.0 || ^3.2.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Allow Firebase JS SDK v11 as peer dependency as it does not have breaking changes affecting `vuefire` according to its [changelog](https://firebase.google.com/support/release-notes/js#version_1100_-_october_21_2024).

Closes: #1581 