### PR TITLE
fix(docs): update nuxt-vuefire sidebar link

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -280,7 +280,10 @@ function sidebarApi(): SidebarGroup {
     text: 'API Reference',
     items: [
       { text: 'Package List', link: '/api/' },
-      { text: 'nuxt-vuefire', link: '/api/modules/nuxt_vuefire.html' },
+      {
+        text: 'nuxt-vuefire',
+        link: '/api/modules/packages_nuxt_src_module.html',
+      },
       { text: 'vuefire', link: '/api/modules/vuefire.html' },
     ],
   }


### PR DESCRIPTION
Fixes #1585 by updating the link in the sidebar to the correct path.