### PR TITLE
Typo on "Getting started" doc

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -38,7 +38,7 @@ Most of the time, you should gather collection references in one of your files a
 
 ```js
 import { initializeApp } from 'firebase/app'
-import { getDatabase, dbRef } from 'firebase/database'
+import { getDatabase, ref as dbRef } from 'firebase/database'
 // ... other firebase imports
 
 export const firebaseApp = initializeApp({


### PR DESCRIPTION
When following [the documentation to try and implement Firebase](https://vuefire.vuejs.org/guide/getting-started.html)  for a Nuxt project I stumbled upon a typo where the import for a database reference was a written as `import { getDatabase, dbRef } from 'firebase/database'` as opposed to `import { getDatabase, ref as dbRef } from 'firebase/database'` as the rest of the document.



