### PR TITLE
Add useRole configuration option for Firebase App Hosting

### DIFF
--- a/docs/nuxt/getting-started.md
+++ b/docs/nuxt/getting-started.md
@@ -89,6 +89,9 @@ export default defineNuxtConfig({
     auth: {
       enabled: true
     },
+    // If using Firebase App Hosting, to use role based authentication instead of GOOGLE_APPLICATION_CREDENTIALS, 
+    // set useRole: true
+    useRole: false,
     appCheck: {
       // Allows you to use a debug token in development
       debug: process.env.NODE_ENV !== 'production',

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -41,6 +41,7 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
   defaults: {
     optionsApiPlugin: false,
     emulators: { enabled: true },
+    useRole: false,
   },
 
   async setup(_options, nuxt) {
@@ -76,6 +77,7 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
         popupRedirectResolver: 'browser',
         ...(typeof _options.auth === 'object' ? _options.auth : {}),
       },
+      useRole: _options.useRole,
     } satisfies VueFireNuxtModuleOptionsResolved
 
     nuxt.options.runtimeConfig.public.vuefire ??= {}
@@ -109,8 +111,9 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
     // This one is set by servers, we set the GOOGLE_APPLICATION_CREDENTIALS env variable instead that has a lower priority and can be both a path or a JSON string
     // process.env.FIREBASE_CONFIG ||= JSON.stringify(options.config)
     const hasServiceAccount =
-      typeof process.env.GOOGLE_APPLICATION_CREDENTIALS === 'string' &&
-      process.env.GOOGLE_APPLICATION_CREDENTIALS.length > 0
+      options.useRole ||
+      (typeof process.env.GOOGLE_APPLICATION_CREDENTIALS === 'string' &&
+        process.env.GOOGLE_APPLICATION_CREDENTIALS.length > 0)
 
     // resolve the credentials in case of monorepos and other projects started from a different folder
     if (
@@ -128,9 +131,13 @@ export default defineNuxtModule<VueFireNuxtModuleOptions>({
     // plugins
 
     if (options.appCheck) {
-      if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && emulatorsConfig) {
+      if (
+        !options.useRole &&
+        !process.env.GOOGLE_APPLICATION_CREDENTIALS &&
+        emulatorsConfig
+      ) {
         logger.info(
-          'Disabling App Check in the context of emulators as no "GOOGLE_APPLICATION_CREDENTIALS" env variable was defined.'
+          'Disabling App Check in the context of emulators as no "GOOGLE_APPLICATION_CREDENTIALS" env variable was defined and no useRole authentication.'
         )
       } else {
         if (

--- a/packages/nuxt/src/module/options.ts
+++ b/packages/nuxt/src/module/options.ts
@@ -46,6 +46,13 @@ export interface VueFireNuxtModuleOptions {
   }
 
   /**
+   * If `true` uses role based authentication instead of environment variable GOOGLE_ACCOUNT_CREDENTIALS.
+   * Be sure the role `Service Account Token Creator`, which has the permission `iam.serviceAccounts.signBlob`
+   * is assigned to the Firebase App Hosting compute user.
+   */
+  useRole?: boolean
+
+  /**
    * Enables AppCheck on the client and server. Note you only need to pass the options for the client, on the server,
    * the configuration will be handled automatically.
    */

--- a/packages/nuxt/src/module/options.ts
+++ b/packages/nuxt/src/module/options.ts
@@ -46,7 +46,7 @@ export interface VueFireNuxtModuleOptions {
   }
 
   /**
-   * If `true` uses role based authentication instead of environment variable GOOGLE_ACCOUNT_CREDENTIALS.
+   * If `true` uses role based authentication instead of environment variable GOOGLE_APPLICATION_CREDENTIALS.
    * Be sure the role `Service Account Token Creator`, which has the permission `iam.serviceAccounts.signBlob`
    * is assigned to the Firebase App Hosting compute user.
    */

--- a/packages/nuxt/tests/fixtures/basic/nuxt.config.ts
+++ b/packages/nuxt/tests/fixtures/basic/nuxt.config.ts
@@ -10,6 +10,7 @@ export default defineNuxtConfig({
       // popupRedirectResolver: false,
       // persistence: ['indexedDBLocal']
     },
+    useRole: false,
     appCheck: {
       // TODO: could automatically pick up a debug token defined as an env variable
       debug: process.env.NODE_ENV !== 'production',


### PR DESCRIPTION
Firebase App Hosting configures the backend server so that it can use Role based authentication instead of needing a file for GOOGLE_APPLICATION_CREDENTIALS.   Therefore, it is not necessary for the nuxt-vuefire module to warn that the GAC environment variable is missing and not initialize the firebase application on the server side.  

This PR adds a new configuration option to nuxt-vuefire to specify that the server is going to use role based authentication and the GOOGLE_APPLICATION_CREDENTIALS environment variable is not necessary.  

This fixes issue #1636 when deploying to Firebase App Hosting so you do not need to add an additional unnecessary credential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `useRole` option to enable role-based authentication for Firebase App Hosting (defaults to false).
  * App Check behavior updated to work smoothly when role-based authentication is enabled.

* **Documentation**
  * Docs updated with guidance and examples for configuring and using role-based authentication with VueFire.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->