### PR TITLE
fix(firestore): resolve nested reference lifecycle

### DIFF
--- a/src/firestore/bind.ts
+++ b/src/firestore/bind.ts
@@ -99,6 +99,7 @@ interface FirestoreSubscription {
   // Firestore unique key eg: items/12
   path: string
   data: () => DocumentData | null
+  resolved: boolean
   // // path inside the object to access the data items.3
   // key: string
 }
@@ -166,6 +167,7 @@ function subscribeToDocument(
 ) {
   const subs = Object.create(null)
   let unbind = noop
+  let active = true
 
   if (options.once) {
     getDoc(ref)
@@ -192,21 +194,27 @@ function subscribeToDocument(
     unbind = onSnapshot(
       ref,
       (snapshot) => {
-        if (snapshot.exists()) {
-          updateDataFromDocumentSnapshot(
-            options,
-            target,
-            path,
-            snapshot,
-            subs,
-            ops,
-            depth,
-            resolve,
-            reject
-          )
-        } else {
-          ops.set(target, path, null)
-          resolve()
+        if (!active) return
+
+        try {
+          if (snapshot.exists()) {
+            updateDataFromDocumentSnapshot(
+              options,
+              target,
+              path,
+              snapshot,
+              subs,
+              ops,
+              depth,
+              resolve,
+              reject
+            )
+          } else {
+            ops.set(target, path, null)
+            resolve()
+          }
+        } catch (error) {
+          reject(error)
         }
       },
       reject
@@ -214,9 +222,21 @@ function subscribeToDocument(
   }
 
   return () => {
+    active = false
     unbind()
     unsubscribeAll(subs)
   }
+}
+
+type ReferenceResolutionWaiter = () => void
+
+const pendingRefResolutions = new WeakMap<
+  Record<string, FirestoreSubscription>,
+  Set<ReferenceResolutionWaiter>
+>()
+
+function notifyRefWaiters(waiters: Set<ReferenceResolutionWaiter>) {
+  Array.from(waiters).forEach((waiter) => waiter())
 }
 
 // NOTE: not convinced by the naming of subscribeToRefs and subscribeToDocument
@@ -242,48 +262,80 @@ function subscribeToRefs(
     subs[refKey].unsub()
     delete subs[refKey]
   })
+
+  let waiters = pendingRefResolutions.get(subs)
+  if (!waiters) {
+    waiters = new Set()
+    pendingRefResolutions.set(subs, waiters)
+  }
+  if (missingKeys.length) notifyRefWaiters(waiters)
+
   if (!refKeys.length || ++depth > options.maxRefDepth) return resolve(path)
 
-  let resolvedCount = 0
-  const totalToResolve = refKeys.length
-  const validResolves: Record<string, boolean> = Object.create(null)
-  function deepResolve(key: string) {
-    if (key in validResolves) {
-      if (++resolvedCount >= totalToResolve) resolve(path)
+  const waiter = () => {
+    if (
+      !refKeys.every((refKey) => !(refKey in subs) || subs[refKey].resolved)
+    ) {
+      return
     }
+
+    waiters.delete(waiter)
+    resolve(path)
   }
+  waiters.add(waiter)
 
   refKeys.forEach((refKey) => {
     const sub = subs[refKey]
     const ref = refs[refKey]
     const docPath = `${path}.${refKey}`
 
-    validResolves[docPath] = true
-
     // unsubscribe if bound to a different ref
     if (sub) {
-      if (sub.path !== ref.path) sub.unsub()
-      // if has already be bound and as we always walk the objects, it will work
-      else return
+      if (sub.path === ref.path) return
+      sub.unsub()
     }
 
-    subs[refKey] = {
-      data: () => walkGet(target, docPath),
-      unsub: subscribeToDocument(
-        {
-          ref,
-          target,
-          path: docPath,
-          depth,
-          ops,
-          resolve: deepResolve.bind(null, docPath),
-          reject,
-        },
-        options
-      ),
+    let cachedData: DocumentData | null | undefined
+    const entry: FirestoreSubscription = (subs[refKey] = {
+      data: () => cachedData ?? walkGet(target, docPath),
       path: ref.path,
+      resolved: false,
+      unsub: noop,
+    })
+    const entryOps: OperationsType = {
+      ...ops,
+      set(target, key, value) {
+        if (key === docPath) {
+          cachedData = value as DocumentData | null
+        } else if (
+          cachedData != null &&
+          typeof cachedData === 'object' &&
+          typeof walkGet(target, docPath) === 'string'
+        ) {
+          ops.set(target, docPath, cachedData)
+        }
+        return ops.set(target, key, value)
+      },
     }
+
+    entry.unsub = subscribeToDocument(
+      {
+        ref,
+        target,
+        path: docPath,
+        depth,
+        ops: entryOps,
+        resolve: () => {
+          entry.resolved = true
+          notifyRefWaiters(waiters)
+        },
+        reject,
+      },
+      options
+    )
   })
+
+  waiter()
 }
 
 // TODO: Remove ops and use just a getter function to be able to retrieve the current target ref and make things work with wait as well
@@ -340,6 +392,10 @@ export function bindCollection<T = unknown>(
       const array = toValue(arrayRef)
       const subs = arraySubs[oldIndex]
       const oldData = array[oldIndex]
+      if (oldIndex !== newIndex) {
+        unsubscribeAll(subs)
+        Object.keys(subs).forEach((key) => delete subs[key])
+      }
       const [data, refs] = extractRefs(
         // @ts-expect-error: FIXME: Better types
         doc.data(snapshotOptions),
@@ -347,9 +403,10 @@ export function bindCollection<T = unknown>(
         subs,
         options
       )
-      // only move things around after extracting refs
-      // only move things around after extracting refs
-      arraySubs.splice(newIndex, 0, subs)
+      if (oldIndex !== newIndex) {
+        arraySubs.splice(oldIndex, 1)
+        arraySubs.splice(newIndex, 0, subs)
+      }
       ops.remove(array, oldIndex)
       ops.add(array, newIndex, data)
       subscribeToRefs(
@@ -364,10 +421,11 @@ export function bindCollection<T = unknown>(
         reject
       )
     },
-    removed: ({ oldIndex }: DocumentChange<T>) => {
+    removed: ({ oldIndex, doc }: DocumentChange<T>) => {
       const array = toValue(arrayRef)
       ops.remove(array, oldIndex)
       unsubscribeAll(arraySubs.splice(oldIndex, 1)[0])
+      resolve(doc)
     },
   }
 

--- a/src/firestore/bind.ts
+++ b/src/firestore/bind.ts
@@ -392,7 +392,18 @@ export function bindCollection<T = unknown>(
       const array = toValue(arrayRef)
       const subs = arraySubs[oldIndex]
       const oldData = array[oldIndex]
+      // indexed paths are stale after a move so subscriptions must be recreated
+      // while still exposing the values they had already resolved
+      let resolvedSubs: Record<
+        string,
+        { path: string; data: () => DocumentData | null }
+      > = subs
       if (oldIndex !== newIndex) {
+        resolvedSubs = Object.keys(subs).reduce((resolved, key) => {
+          const data = subs[key].data()
+          resolved[key] = { path: subs[key].path, data: () => data }
+          return resolved
+        }, Object.create(null))
         unsubscribeAll(subs)
         Object.keys(subs).forEach((key) => delete subs[key])
       }
@@ -400,7 +411,7 @@ export function bindCollection<T = unknown>(
         // @ts-expect-error: FIXME: Better types
         doc.data(snapshotOptions),
         oldData,
-        subs,
+        resolvedSubs,
         options
       )
       if (oldIndex !== newIndex) {
@@ -451,6 +462,8 @@ export function bindCollection<T = unknown>(
 
       resolve = (data) => {
         if (data && (data as any).id in validDocs) {
+          // a document can be resolved by its refs and by its removal
+          delete validDocs[(data as any).id]
           if (++count >= expectedItems) {
             // if wait is true, finally set the array
             if (wait) {

--- a/src/firestore/utils.ts
+++ b/src/firestore/utils.ts
@@ -102,7 +102,7 @@ export function extractRefs(
           // otherwise set the path as a string so it can be bound later
           // https://github.com/vuejs/vuefire/issues/831
           // https://github.com/vuejs/vuefire/pull/1223
-          refSubKey in subs ? oldDoc[key] : ref.path
+          refSubKey in subs ? subs[refSubKey].data() : ref.path
         // TODO: handle subpathes?
         refs[refSubKey] = ref.converter
           ? ref

--- a/tests/firestore/refs-in-collections-lifecycle.spec.ts
+++ b/tests/firestore/refs-in-collections-lifecycle.spec.ts
@@ -1,0 +1,259 @@
+import { ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { bindCollection } from '../../src/firestore/bind'
+import { ops } from '../../src/firestore/useFirestoreRef'
+
+const snapshots = vi.hoisted(() => {
+  type Listener = (snapshot: unknown) => void
+
+  return {
+    collections: [] as Listener[],
+    documents: new Map<string, Listener[]>(),
+  }
+})
+
+vi.mock('firebase/firestore', () => {
+  class Timestamp {}
+  class GeoPoint {}
+
+  return {
+    Timestamp,
+    GeoPoint,
+    getDoc: vi.fn(),
+    getDocs: vi.fn(),
+    onSnapshot: (
+      source: { path: string; type: string },
+      next: (snapshot: unknown) => void
+    ) => {
+      const listeners =
+        source.type === 'document'
+          ? snapshots.documents.get(source.path) || []
+          : snapshots.collections
+
+      listeners.push(next)
+      if (source.type === 'document') {
+        snapshots.documents.set(source.path, listeners)
+      }
+
+      return () => {
+        const index = listeners.indexOf(next)
+        if (index >= 0) listeners.splice(index, 1)
+      }
+    },
+  }
+})
+
+function documentReference(path: string) {
+  return {
+    type: 'document',
+    path,
+    converter: null,
+    withConverter(converter: unknown) {
+      return { ...this, converter }
+    },
+  }
+}
+
+const collectionReference = {
+  type: 'collection',
+  path: 'messages',
+}
+
+function emitCollection(
+  changes: Array<{
+    type: string
+    oldIndex: number
+    newIndex: number
+    doc: { id: string; data: () => Record<string, unknown> }
+  }>
+) {
+  const snapshot = {
+    docChanges: () => changes,
+  }
+  snapshots.collections.forEach((listener) => listener(snapshot))
+}
+
+function emitDocument(path: string, data: Record<string, unknown>) {
+  const snapshot = {
+    exists: () => true,
+    data: () => data,
+  }
+  snapshots.documents.get(path)?.forEach((listener) => listener(snapshot))
+}
+
+function messageChange(
+  type: string,
+  data: Record<string, unknown>,
+  { id = 'message-1', oldIndex = 0, newIndex = 0 } = {}
+) {
+  return {
+    type,
+    oldIndex: type === 'added' ? -1 : oldIndex,
+    newIndex,
+    doc: { id, data: () => data },
+  }
+}
+
+function bindMessages() {
+  const target = ref<unknown[]>([])
+  let resolveBinding!: (value: unknown) => void
+  let rejectBinding!: (reason: unknown) => void
+  const promise = new Promise((resolve, reject) => {
+    resolveBinding = resolve
+    rejectBinding = reject
+  })
+
+  const stop = bindCollection(
+    target,
+    collectionReference as never,
+    ops,
+    resolveBinding,
+    rejectBinding,
+    { maxRefDepth: 2, wait: true }
+  )
+
+  return { promise, stop, target }
+}
+
+describe('Firestore nested reference lifecycle', () => {
+  beforeEach(() => {
+    snapshots.collections.length = 0
+    snapshots.documents.clear()
+  })
+
+  it('resolves when a reference path changes during the initial snapshot', async () => {
+    const { promise, stop, target } = bindMessages()
+
+    emitCollection([
+      messageChange('added', {
+        sender: documentReference('agents/a1'),
+        updatedBy: documentReference('members/m1'),
+      }),
+    ])
+    emitDocument('agents/a1', { name: 'Ada' })
+
+    emitCollection([
+      messageChange('modified', {
+        sender: documentReference('agents/a1'),
+        updatedBy: documentReference('members/m2'),
+      }),
+    ])
+    emitDocument('members/m2', { name: 'Bob' })
+
+    await promise
+    expect(target.value).toHaveLength(1)
+    stop()
+  })
+
+  it('resolves when a document is removed before its references', async () => {
+    const { promise, stop, target } = bindMessages()
+
+    const data = { sender: documentReference('agents/a1') }
+    emitCollection([messageChange('added', data)])
+    emitCollection([messageChange('removed', data)])
+
+    await promise
+    expect(target.value).toHaveLength(0)
+    stop()
+  })
+
+  it('resolves when a reference disappears during the initial snapshot', async () => {
+    const { promise, stop, target } = bindMessages()
+
+    emitCollection([
+      messageChange('added', {
+        sender: documentReference('agents/a1'),
+        summary: documentReference('summaries/s1'),
+      }),
+    ])
+    emitDocument('agents/a1', { name: 'Ada' })
+
+    emitCollection([
+      messageChange('modified', {
+        sender: documentReference('agents/a1'),
+      }),
+    ])
+
+    await promise
+    expect(target.value).toEqual([{ sender: { name: 'Ada' } }])
+    stop()
+  })
+
+  it('rebinds nested references when a collection document moves', async () => {
+    const { promise, stop, target } = bindMessages()
+
+    emitCollection([
+      messageChange(
+        'added',
+        { sender: documentReference('agents/a1') },
+        { id: 'message-1', newIndex: 0 }
+      ),
+      messageChange(
+        'added',
+        { sender: documentReference('agents/a2') },
+        { id: 'message-2', newIndex: 1 }
+      ),
+    ])
+    emitDocument('agents/a1', {
+      name: 'Ada',
+      createdBy: documentReference('members/m1'),
+    })
+    emitDocument('agents/a2', {
+      name: 'Bob',
+      createdBy: documentReference('members/m2'),
+    })
+    emitDocument('members/m1', { name: 'Alice' })
+    emitDocument('members/m2', { name: 'Bruno' })
+    await promise
+
+    emitCollection([
+      messageChange(
+        'modified',
+        { sender: documentReference('agents/a1') },
+        { id: 'message-1', oldIndex: 0, newIndex: 1 }
+      ),
+    ])
+    emitDocument('agents/a1', {
+      name: 'Ada moved',
+      createdBy: documentReference('members/m3'),
+    })
+    emitDocument('members/m3', { name: 'Charlie' })
+
+    expect(target.value).toEqual([
+      {
+        sender: { name: 'Bob', createdBy: { name: 'Bruno' } },
+      },
+      {
+        sender: { name: 'Ada moved', createdBy: { name: 'Charlie' } },
+      },
+    ])
+    stop()
+  })
+
+  it('restores resolved parent data before a nested listener writes', async () => {
+    const { promise, stop, target } = bindMessages()
+
+    emitCollection([
+      messageChange('added', {
+        sender: documentReference('agents/a1'),
+      }),
+    ])
+    emitDocument('agents/a1', {
+      name: 'Ada',
+      createdBy: documentReference('members/m1'),
+    })
+    emitDocument('members/m1', { name: 'Alice' })
+    await promise
+
+    const message = target.value[0] as { sender: unknown }
+    message.sender = 'agents/a1'
+    expect(() =>
+      emitDocument('members/m1', { name: 'Alice updated' })
+    ).not.toThrow()
+    expect(message.sender).toEqual({
+      name: 'Ada',
+      createdBy: { name: 'Alice updated' },
+    })
+    stop()
+  })
+})

--- a/tests/firestore/refs-in-collections-lifecycle.spec.ts
+++ b/tests/firestore/refs-in-collections-lifecycle.spec.ts
@@ -70,7 +70,7 @@ function emitCollection(
   const snapshot = {
     docChanges: () => changes,
   }
-  snapshots.collections.forEach((listener) => listener(snapshot))
+  Array.from(snapshots.collections).forEach((listener) => listener(snapshot))
 }
 
 function emitDocument(path: string, data: Record<string, unknown>) {
@@ -78,7 +78,8 @@ function emitDocument(path: string, data: Record<string, unknown>) {
     exists: () => true,
     data: () => data,
   }
-  snapshots.documents.get(path)?.forEach((listener) => listener(snapshot))
+  const listeners = snapshots.documents.get(path)
+  if (listeners) Array.from(listeners).forEach((listener) => listener(snapshot))
 }
 
 function messageChange(
@@ -98,8 +99,12 @@ function bindMessages() {
   const target = ref<unknown[]>([])
   let resolveBinding!: (value: unknown) => void
   let rejectBinding!: (reason: unknown) => void
+  let resolvedWith: unknown
   const promise = new Promise((resolve, reject) => {
-    resolveBinding = resolve
+    resolveBinding = (value) => {
+      resolvedWith ??= JSON.parse(JSON.stringify(value))
+      resolve(value)
+    }
     rejectBinding = reject
   })
 
@@ -112,7 +117,7 @@ function bindMessages() {
     { maxRefDepth: 2, wait: true }
   )
 
-  return { promise, stop, target }
+  return { promise, stop, target, resolvedWith: () => resolvedWith }
 }
 
 describe('Firestore nested reference lifecycle', () => {
@@ -213,6 +218,10 @@ describe('Firestore nested reference lifecycle', () => {
         { id: 'message-1', oldIndex: 0, newIndex: 1 }
       ),
     ])
+    expect(target.value[1]).toEqual({
+      sender: { name: 'Ada', createdBy: { name: 'Alice' } },
+    })
+
     emitDocument('agents/a1', {
       name: 'Ada moved',
       createdBy: documentReference('members/m3'),
@@ -227,6 +236,36 @@ describe('Firestore nested reference lifecycle', () => {
         sender: { name: 'Ada moved', createdBy: { name: 'Charlie' } },
       },
     ])
+    stop()
+  })
+
+  it('does not resolve early when a document is removed after resolving', async () => {
+    const { promise, stop, resolvedWith } = bindMessages()
+
+    emitCollection([
+      messageChange(
+        'added',
+        { sender: documentReference('agents/a1') },
+        { id: 'message-1', newIndex: 0 }
+      ),
+      messageChange(
+        'added',
+        { sender: documentReference('agents/a2') },
+        { id: 'message-2', newIndex: 1 }
+      ),
+    ])
+    emitDocument('agents/a2', { name: 'Bob' })
+    emitCollection([
+      messageChange(
+        'removed',
+        { sender: documentReference('agents/a2') },
+        { id: 'message-2', oldIndex: 1 }
+      ),
+    ])
+    emitDocument('agents/a1', { name: 'Ada' })
+
+    await promise
+    expect(resolvedWith()).toEqual([{ sender: { name: 'Ada' } }])
     stop()
   })
 


### PR DESCRIPTION
## Problem

`subscribeToRefs()` keeps subscriptions across snapshots but recreates its resolution counter for each call. If a nested reference changes, disappears, or its collection document is removed or moved before initial resolution, the binding can lose resolution credit and stay pending with `wait: true`.

## Fix

- Keep resolution state on persistent subscriptions and notify every waiting snapshot.
- Rebind indexed reference paths when collection documents move and resolve removed documents.
- Preserve resolved parent data for nested updates and ignore callbacks from disposed listeners.

## Tests

Added deterministic coverage for path changes, removed documents, disappearing references, collection moves, and nested updates.

- `pnpm exec vitest run tests/firestore/refs-in-collections-lifecycle.spec.ts`
- `pnpm run lint`
- `pnpm run test:types`
- `pnpm run build`
- `pnpm run -C packages/nuxt build`

The full emulator suite will run in CI; the local machine has no Java runtime.

## Temporary workaround

Until this is released, consumers can backport the change with `pnpm patch`. Explicitly limiting `maxRefDepth` and using bounded waits with direct Firestore reads on critical paths reduce the impact, but do not fix the lifecycle race.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of nested Firestore references during document and collection updates.
  - Prevented updates after listeners are unsubscribed and improved handling of synchronous listener errors.
  - Preserved resolved reference data during document moves, removals, reordering, and nested updates.
  - Ensured removed documents resolve with their final available data.
  - Prevented duplicate resolution and stale data when references change.
  - Maintained correct bindings as collection rows are added, removed, or reordered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->